### PR TITLE
fix: 修复配置文件读取问题

### DIFF
--- a/cmd/ui/service/web.go
+++ b/cmd/ui/service/web.go
@@ -71,7 +71,7 @@ func NewWebServer(ctx context.Context, addr string, addrs []string) (*WebServer,
 	}
 
 	// 鉴权器
-	authorizer, err := auth.NewAuthorizer(dis, cc.TLSConfig{})
+	authorizer, err := auth.NewAuthorizer(dis, cc.TLSConfig{}, auth.WithIsDevMode(config.G.IsDevMode))
 	if err != nil {
 		return nil, fmt.Errorf("new authorizer failed, err: %v", err)
 	}

--- a/internal/iam/auth/auth.go
+++ b/internal/iam/auth/auth.go
@@ -76,7 +76,7 @@ type Authorizer interface {
 }
 
 // NewAuthorizer create an authorizer for iam authorize related operation.
-func NewAuthorizer(sd serviced.Discover, tls cc.TLSConfig) (Authorizer, error) {
+func NewAuthorizer(sd serviced.Discover, tls cc.TLSConfig, authOpts ...Option) (Authorizer, error) {
 	opts := make([]grpc.DialOption, 0)
 
 	// add dial load balancer.
@@ -167,6 +167,7 @@ func NewAuthorizer(sd serviced.Discover, tls cc.TLSConfig) (Authorizer, error) {
 		authLoginClient: authLoginClient,
 		gwParser:        nil,
 		spaceMgr:        spaceMgr,
+		isDevMode:       func() bool { return cc.G().IsDevMode() },
 	}
 
 	// 如果有公钥，初始化配置
@@ -178,6 +179,11 @@ func NewAuthorizer(sd serviced.Discover, tls cc.TLSConfig) (Authorizer, error) {
 
 		authz.gwParser = gwParser
 		klog.InfoS("init gw parser done", "fingerprint", gwParser.Fingerprint())
+	}
+
+	// apply options
+	for _, opt := range authOpts {
+		opt(authz)
 	}
 
 	return authz, nil
@@ -256,6 +262,17 @@ type authorizer struct {
 	authLoginClient bkpaas.AuthLoginClient
 	gwParser        gwparser.Parser
 	spaceMgr        *space.Manager
+	isDevMode       func() bool
+}
+
+// Option defines the option for NewAuthorizer.
+type Option func(*authorizer)
+
+// WithIsDevMode set the is dev mode check function.
+func WithIsDevMode(fn func() bool) Option {
+	return func(a *authorizer) {
+		a.isDevMode = fn
+	}
 }
 
 // AuthorizeDecision if user has permission to the resources, returns auth status per resource and for all.

--- a/internal/iam/auth/middleware.go
+++ b/internal/iam/auth/middleware.go
@@ -113,7 +113,7 @@ func (a authorizer) initKitWithCookie(r *http.Request, k *kit.Kit, multiErr *mul
 
 // initKitWithDevEnv Dev环境, 可以设置环境变量鉴权
 func (a authorizer) initKitWithDevEnv(r *http.Request, k *kit.Kit, _ *multierror.Error) bool {
-	if !cc.G().IsDevMode() {
+	if !a.isDevMode() {
 		return false
 	}
 	user := os.Getenv("BK_USER_FOR_TEST")


### PR DESCRIPTION
initKitWithDevEnv 被 WebAuthentication(UI) 和 UnifiedAuthentication(API) 共用，内部 cc.G().IsDevMode() 依赖 globalSettings 指针，而 UI 服务未调用 cc.LoadSettings() 导致 nil panic。