### PR TITLE
--story=134750511 适配 gsekit 配置模版

### DIFF
--- a/cmd/data-service/db-migration/migrations/20260528170000_add_config_template_name_to_templates.go
+++ b/cmd/data-service/db-migration/migrations/20260528170000_add_config_template_name_to_templates.go
@@ -1,0 +1,82 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/TencentBlueKing/bk-bscp/cmd/data-service/db-migration/migrator"
+)
+
+func init() {
+	migrator.GetMigrator().AddMigration(&migrator.Migration{
+		Version: "20260528170000",
+		Name:    "20260528170000_add_config_template_name_to_templates",
+		Mode:    migrator.GormMode,
+		Up:      mig20260528170000Up,
+		Down:    mig20260528170000Down,
+	})
+}
+
+func mig20260528170000Up(tx *gorm.DB) error {
+	// 1. Add config_template_name column
+	if !tx.Migrator().HasColumn("templates", "config_template_name") {
+		if err := tx.Exec("ALTER TABLE `templates` ADD COLUMN `config_template_name` varchar(255) NOT NULL DEFAULT ''").Error; err != nil {
+			return err
+		}
+	}
+
+	// 2. Drop old unique index
+	if tx.Migrator().HasIndex("templates", "idx_tenantID_bizID_tempSpaID_name_path") {
+		if err := tx.Exec("DROP INDEX `idx_tenantID_bizID_tempSpaID_name_path` ON `templates`").Error; err != nil {
+			return err
+		}
+	}
+
+	// 3. Create new unique index including config_template_name
+	if !tx.Migrator().HasIndex("templates", "idx_tenantID_bizID_tempSpaID_name_path_ctName") {
+		if err := tx.Exec("CREATE UNIQUE INDEX `idx_tenantID_bizID_tempSpaID_name_path_ctName` " +
+			"ON `templates` (`tenant_id`, `biz_id`, `template_space_id`, `name`(100), `path`(100), " +
+			"`config_template_name`(100))").Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mig20260528170000Down(tx *gorm.DB) error {
+	// 1. Drop new unique index
+	if tx.Migrator().HasIndex("templates", "idx_tenantID_bizID_tempSpaID_name_path_ctName") {
+		if err := tx.Exec("DROP INDEX `idx_tenantID_bizID_tempSpaID_name_path_ctName` ON `templates`").Error; err != nil {
+			return err
+		}
+	}
+
+	// 2. Restore old unique index
+	if !tx.Migrator().HasIndex("templates", "idx_tenantID_bizID_tempSpaID_name_path") {
+		if err := tx.Exec("CREATE UNIQUE INDEX `idx_tenantID_bizID_tempSpaID_name_path` " +
+			"ON `templates` (`tenant_id`, `biz_id`, `template_space_id`, `name`(100), `path`(100))").Error; err != nil {
+			return err
+		}
+	}
+
+	// 3. Drop config_template_name column
+	if tx.Migrator().HasColumn("templates", "config_template_name") {
+		if err := tx.Exec("ALTER TABLE `templates` DROP COLUMN `config_template_name`").Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/data-service/db-migration/migrations/20260528170000_add_config_template_name_to_templates.go
+++ b/cmd/data-service/db-migration/migrations/20260528170000_add_config_template_name_to_templates.go
@@ -36,14 +36,24 @@ func mig20260528170000Up(tx *gorm.DB) error {
 		}
 	}
 
-	// 2. Drop old unique index
+	// 2. Backfill config_template_name from config_templates for existing records in config_delivery spaces
+	if err := tx.Exec(
+		"UPDATE `templates` t " +
+			"INNER JOIN `config_templates` ct ON ct.template_id = t.id AND ct.biz_id = t.biz_id " +
+			"INNER JOIN `template_spaces` ts ON ts.id = t.template_space_id AND ts.biz_id = t.biz_id " +
+			"SET t.config_template_name = ct.name " +
+			"WHERE t.config_template_name = '' AND ts.name = 'config_delivery'").Error; err != nil {
+		return err
+	}
+
+	// 3. Drop old unique index
 	if tx.Migrator().HasIndex("templates", "idx_tenantID_bizID_tempSpaID_name_path") {
 		if err := tx.Exec("DROP INDEX `idx_tenantID_bizID_tempSpaID_name_path` ON `templates`").Error; err != nil {
 			return err
 		}
 	}
 
-	// 3. Create new unique index including config_template_name
+	// 4. Create new unique index including config_template_name
 	if !tx.Migrator().HasIndex("templates", "idx_tenantID_bizID_tempSpaID_name_path_ctName") {
 		if err := tx.Exec("CREATE UNIQUE INDEX `idx_tenantID_bizID_tempSpaID_name_path_ctName` " +
 			"ON `templates` (`tenant_id`, `biz_id`, `template_space_id`, `name`(100), `path`(100), " +

--- a/cmd/data-service/service/config_template.go
+++ b/cmd/data-service/service/config_template.go
@@ -403,21 +403,23 @@ func (s *Service) CreateConfigTemplate(ctx context.Context, req *pbds.CreateConf
 	now := time.Now().UTC()
 
 	// 2. 校验同一空间下不能出现相同绝对路径的配置文件且同路径下不能出现同名的文件夹和文件
-	items, _, err := s.dao.Template().List(kit, req.GetBizId(),
-		req.GetTemplateSpaceId(), &types.BasePage{All: true})
-	if err != nil {
-		return nil, errf.Errorf(errf.DBOpFailed, "%s",
-			i18n.T(kit, "list templates failed, err: %v", err))
-	}
-	existingPaths := []string{}
-	for _, v := range items {
-		existingPaths = append(existingPaths, path.Join(v.Spec.Path, v.Spec.Name))
-	}
+	// config_delivery 空间允许不同配置模版使用相同路径，由 DB 唯一索引 (name, path, config_template_name) 保证唯一性
+	if !s.isConfigDeliverySpace(kit, req.GetBizId(), req.GetTemplateSpaceId()) {
+		items, _, err := s.dao.Template().List(kit, req.GetBizId(),
+			req.GetTemplateSpaceId(), &types.BasePage{All: true})
+		if err != nil {
+			return nil, errf.Errorf(errf.DBOpFailed, "%s",
+				i18n.T(kit, "list templates failed, err: %v", err))
+		}
+		existingPaths := []string{}
+		for _, v := range items {
+			existingPaths = append(existingPaths, path.Join(v.Spec.Path, v.Spec.Name))
+		}
 
-	// 检测文件路径是否存在冲突
-	if tools.CheckPathConflict(req.GetFullPath(), existingPaths) {
-		return nil, errors.New(i18n.T(kit, "the config file %s already exists in this space and cannot be created again",
-			req.GetFullPath()))
+		if tools.CheckPathConflict(req.GetFullPath(), existingPaths) {
+			return nil, errors.New(i18n.T(kit, "the config file %s already exists in this space and cannot be created again",
+				req.GetFullPath()))
+		}
 	}
 
 	// 3. 通过空间和名称查询套餐
@@ -488,9 +490,10 @@ func (s *Service) createTemplateAndRevision(kit *kit.Kit, tx *gen.QueryTx, templ
 	// 1. 创建模板文件
 	template := &table.Template{
 		Spec: &table.TemplateSpec{
-			Name: fileName,
-			Path: filePath,
-			Memo: req.GetTemplateMemo(),
+			Name:               fileName,
+			Path:               filePath,
+			Memo:               req.GetTemplateMemo(),
+			ConfigTemplateName: req.GetTemplateName(),
 		},
 		Attachment: &table.TemplateAttachment{
 			BizID:           req.GetBizId(),
@@ -632,6 +635,16 @@ func (s *Service) getOrCreateDefaultTemplateSet(kit *kit.Kit, bizID, spaceID uin
 	}
 
 	return set, nil
+}
+
+// isConfigDeliverySpace 判断指定模板空间是否为 config_delivery 系统空间。
+// config_delivery 空间允许不同配置模版使用相同文件路径（由 DB 唯一索引中的 config_template_name 区分）。
+func (s *Service) isConfigDeliverySpace(kit *kit.Kit, bizID, templateSpaceID uint32) bool {
+	space, err := s.dao.TemplateSpace().Get(kit, bizID, templateSpaceID)
+	if err != nil {
+		return false
+	}
+	return space.Spec.Name == constant.CONFIG_DELIVERY
 }
 
 // ServiceTemplate implements pbds.DataServer.
@@ -1065,9 +1078,10 @@ func (s *Service) UpdateConfigTemplate(ctx context.Context, req *pbds.UpdateConf
 	err = s.dao.Template().UpdateWithTx(grpcKit, tx, &table.Template{
 		ID: template.ID,
 		Spec: &table.TemplateSpec{
-			Memo: req.GetRevisionMemo(),
-			Path: filePath,
-			Name: fileName,
+			Memo:               req.GetRevisionMemo(),
+			Path:               filePath,
+			Name:               fileName,
+			ConfigTemplateName: req.GetTemplateName(),
 		},
 		Attachment: template.Attachment,
 		Revision:   template.Revision,

--- a/cmd/data-service/service/config_template.go
+++ b/cmd/data-service/service/config_template.go
@@ -402,34 +402,14 @@ func (s *Service) CreateConfigTemplate(ctx context.Context, req *pbds.CreateConf
 
 	now := time.Now().UTC()
 
-	// 2. 校验同一空间下不能出现相同绝对路径的配置文件且同路径下不能出现同名的文件夹和文件
-	// config_delivery 空间允许不同配置模版使用相同路径，由 DB 唯一索引 (name, path, config_template_name) 保证唯一性
-	if !s.isConfigDeliverySpace(kit, req.GetBizId(), req.GetTemplateSpaceId()) {
-		items, _, err := s.dao.Template().List(kit, req.GetBizId(),
-			req.GetTemplateSpaceId(), &types.BasePage{All: true})
-		if err != nil {
-			return nil, errf.Errorf(errf.DBOpFailed, "%s",
-				i18n.T(kit, "list templates failed, err: %v", err))
-		}
-		existingPaths := []string{}
-		for _, v := range items {
-			existingPaths = append(existingPaths, path.Join(v.Spec.Path, v.Spec.Name))
-		}
-
-		if tools.CheckPathConflict(req.GetFullPath(), existingPaths) {
-			return nil, errors.New(i18n.T(kit, "the config file %s already exists in this space and cannot be created again",
-				req.GetFullPath()))
-		}
-	}
-
-	// 3. 通过空间和名称查询套餐
+	// 2. 通过空间和名称查询套餐
 	templateSet, err := s.dao.TemplateSet().GetByUniqueKey(kit, req.GetBizId(), req.GetTemplateSpaceId(), constant.DefaultTmplSetName)
 	if err != nil {
 		return nil, errf.Errorf(errf.DBOpFailed, "%s",
 			i18n.T(kit, "get template set failed, err: %v", err))
 	}
 
-	// 4. 创建模板和模板版本，并添加至默认套餐中
+	// 3. 创建模板和模板版本，并添加至默认套餐中
 	templateId, err := s.createTemplateAndRevision(kit, tx, req.GetTemplateSpaceId(), templateSet, req, now)
 	if err != nil {
 		logs.Errorf("[ConfigTemplate] createTemplateAndRevision failed, err=%v, rid=%s", err, kit.Rid)
@@ -437,7 +417,7 @@ func (s *Service) CreateConfigTemplate(ctx context.Context, req *pbds.CreateConf
 			i18n.T(kit, "create template and revision failed, err: %v", err))
 	}
 
-	// 5. 创建配置模板
+	// 4. 创建配置模板
 	configTemplate := &table.ConfigTemplate{
 		Spec: &table.ConfigTemplateSpec{
 			Name:           req.GetTemplateName(),
@@ -464,7 +444,7 @@ func (s *Service) CreateConfigTemplate(ctx context.Context, req *pbds.CreateConf
 			i18n.T(kit, "create config template failed, err: %v", err))
 	}
 
-	// 6. 提交事务
+	// 5. 提交事务
 	if e := tx.Commit(); e != nil {
 		logs.Errorf("[ConfigTemplate] commit transaction failed, err: %v, rid: %s", e, kit.Rid)
 		return nil, errf.Errorf(errf.DBOpFailed, "%s",
@@ -635,16 +615,6 @@ func (s *Service) getOrCreateDefaultTemplateSet(kit *kit.Kit, bizID, spaceID uin
 	}
 
 	return set, nil
-}
-
-// isConfigDeliverySpace 判断指定模板空间是否为 config_delivery 系统空间。
-// config_delivery 空间允许不同配置模版使用相同文件路径（由 DB 唯一索引中的 config_template_name 区分）。
-func (s *Service) isConfigDeliverySpace(kit *kit.Kit, bizID, templateSpaceID uint32) bool {
-	space, err := s.dao.TemplateSpace().Get(kit, bizID, templateSpaceID)
-	if err != nil {
-		return false
-	}
-	return space.Spec.Name == constant.CONFIG_DELIVERY
 }
 
 // ServiceTemplate implements pbds.DataServer.

--- a/internal/dal/gen/templates.gen.go
+++ b/internal/dal/gen/templates.gen.go
@@ -31,6 +31,7 @@ func newTemplate(db *gorm.DB, opts ...gen.DOOption) template {
 	_template.Name = field.NewString(tableName, "name")
 	_template.Path = field.NewString(tableName, "path")
 	_template.Memo = field.NewString(tableName, "memo")
+	_template.ConfigTemplateName = field.NewString(tableName, "config_template_name")
 	_template.BizID = field.NewUint32(tableName, "biz_id")
 	_template.TemplateSpaceID = field.NewUint32(tableName, "template_space_id")
 	_template.TenantID = field.NewString(tableName, "tenant_id")
@@ -47,18 +48,19 @@ func newTemplate(db *gorm.DB, opts ...gen.DOOption) template {
 type template struct {
 	templateDo templateDo
 
-	ALL             field.Asterisk
-	ID              field.Uint32
-	Name            field.String
-	Path            field.String
-	Memo            field.String
-	BizID           field.Uint32
-	TemplateSpaceID field.Uint32
-	TenantID        field.String
-	Creator         field.String
-	Reviser         field.String
-	CreatedAt       field.Time
-	UpdatedAt       field.Time
+	ALL                field.Asterisk
+	ID                 field.Uint32
+	Name               field.String
+	Path               field.String
+	Memo               field.String
+	ConfigTemplateName field.String
+	BizID              field.Uint32
+	TemplateSpaceID    field.Uint32
+	TenantID           field.String
+	Creator            field.String
+	Reviser            field.String
+	CreatedAt          field.Time
+	UpdatedAt          field.Time
 
 	fieldMap map[string]field.Expr
 }
@@ -79,6 +81,7 @@ func (t *template) updateTableName(table string) *template {
 	t.Name = field.NewString(table, "name")
 	t.Path = field.NewString(table, "path")
 	t.Memo = field.NewString(table, "memo")
+	t.ConfigTemplateName = field.NewString(table, "config_template_name")
 	t.BizID = field.NewUint32(table, "biz_id")
 	t.TemplateSpaceID = field.NewUint32(table, "template_space_id")
 	t.TenantID = field.NewString(table, "tenant_id")
@@ -110,11 +113,12 @@ func (t *template) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (t *template) fillFieldMap() {
-	t.fieldMap = make(map[string]field.Expr, 11)
+	t.fieldMap = make(map[string]field.Expr, 12)
 	t.fieldMap["id"] = t.ID
 	t.fieldMap["name"] = t.Name
 	t.fieldMap["path"] = t.Path
 	t.fieldMap["memo"] = t.Memo
+	t.fieldMap["config_template_name"] = t.ConfigTemplateName
 	t.fieldMap["biz_id"] = t.BizID
 	t.fieldMap["template_space_id"] = t.TemplateSpaceID
 	t.fieldMap["tenant_id"] = t.TenantID

--- a/pkg/dal/table/template.go
+++ b/pkg/dal/table/template.go
@@ -133,9 +133,10 @@ func (t *Template) ValidateDelete() error {
 
 // TemplateSpec defines all the specifics for template set by user.
 type TemplateSpec struct {
-	Name string `json:"name" gorm:"column:name"`
-	Path string `json:"path" gorm:"column:path"`
-	Memo string `json:"memo" gorm:"column:memo"`
+	Name               string `json:"name" gorm:"column:name"`
+	Path               string `json:"path" gorm:"column:path"`
+	Memo               string `json:"memo" gorm:"column:memo"`
+	ConfigTemplateName string `json:"config_template_name" gorm:"column:config_template_name"`
 }
 
 // ValidateCreate validate template spec when it is created.


### PR DESCRIPTION
在 templates 表新增 config_template_name 列并纳入唯一索引，允许
config_delivery 空间下不同配置模版使用相同文件路径。旧模板流行为不变。

- 新增 DB migration: 添加列 + 替换唯一索引
- TemplateSpec 增加 ConfigTemplateName 字段
- createTemplateAndRevision 写入配置模版名称
- UpdateConfigTemplate 同步更新配置模版名称
- CreateConfigTemplate 对 config_delivery 空间跳过路径冲突检查