### PR TITLE
--bug=161461287 fix: 修复批量更新模板权限错误返回的格式串注入问题

### DIFF
--- a/cmd/data-service/service/template.go
+++ b/cmd/data-service/service/template.go
@@ -1153,7 +1153,7 @@ func (s *Service) BatchUpdateTemplatePermissions(ctx context.Context, req *pbds.
 	tmps, err := s.dao.TemplateRevision().ListLatestRevisionsGroupByTemplateIds(kt, templateIds)
 	if err != nil {
 		return nil, errf.Errorf(errf.DBOpFailed,
-			i18n.T(kt, fmt.Sprintf("lists the latest version by template ids failed, err: %s", err.Error())))
+			"%s", i18n.T(kt, "lists the latest version by template ids failed, err: %s", err.Error()))
 	}
 
 	now := time.Now().UTC()
@@ -1190,18 +1190,12 @@ func (s *Service) BatchUpdateTemplatePermissions(ctx context.Context, req *pbds.
 	if err := s.dao.Template().BatchUpdateTimeTx(kt, tx, req.TemplateIds); err != nil {
 		logs.Errorf("batch update template time failed, err: %v, rid: %s", err, kt.Rid)
 		return nil, errf.Errorf(errf.DBOpFailed,
-			i18n.T(kt, fmt.Sprintf("batch update of template permissions failed, err: %s", err.Error())))
+			"%s", i18n.T(kt, "batch update of template permissions failed, err: %s", err.Error()))
 	}
 	if err := s.dao.TemplateRevision().BatchCreateWithTx(kt, tx, toCreate); err != nil {
 		logs.Errorf("batch create template revisions failed, err: %v, rid: %s", err, kt.Rid)
 		return nil, errf.Errorf(errf.DBOpFailed,
-			i18n.T(kt, fmt.Sprintf("batch update of template permissions failed, err: %s", err.Error())))
-	}
-
-	if err := s.dao.TemplateRevision().BatchCreateWithTx(kt, tx, toCreate); err != nil {
-		logs.Errorf("batch create template revisions failed, err: %v, rid: %s", err, kt.Rid)
-		return nil, errf.Errorf(errf.DBOpFailed,
-			i18n.T(kt, fmt.Sprintf("batch update of template permissions failed, err: %s", err.Error())))
+			"%s", i18n.T(kt, "batch update of template permissions failed, err: %s", err.Error()))
 	}
 
 	ids := []uint32{}
@@ -1219,7 +1213,7 @@ func (s *Service) BatchUpdateTemplatePermissions(ctx context.Context, req *pbds.
 		if err != nil {
 			logs.Errorf("list app template bindings by app ids failed, err: %v, rid: %s", err, kt.Rid)
 			return nil, errf.Errorf(errf.DBOpFailed,
-				i18n.T(kt, "list app template bindings by app ids failed, err: %s", err))
+				"%s", i18n.T(kt, "list app template bindings by app ids failed, err: %s", err))
 		}
 		for _, item := range items {
 			templateRevisionIDs := make([]uint32, 0, len(item.Spec.Bindings))
@@ -1246,14 +1240,14 @@ func (s *Service) BatchUpdateTemplatePermissions(ctx context.Context, req *pbds.
 		if err := s.dao.AppTemplateBinding().BatchUpdateWithTx(kt, tx, items); err != nil {
 			logs.Errorf("batch update app template bindings failed, err: %v, rid: %s", err, kt.Rid)
 			return nil, errf.Errorf(errf.DBOpFailed,
-				i18n.T(kt, fmt.Sprintf("batch update of template permissions failed, err: %s", err.Error())))
+				"%s", i18n.T(kt, "batch update of template permissions failed, err: %s", err.Error()))
 		}
 	}
 
 	if e := tx.Commit(); e != nil {
 		logs.Errorf("commit transaction failed, err: %v, rid: %s", e, kt.Rid)
 		return nil, errf.Errorf(errf.DBOpFailed,
-			i18n.T(kt, fmt.Sprintf("batch update of template permissions failed, err: %s", e.Error())))
+			"%s", i18n.T(kt, "batch update of template permissions failed, err: %s", e.Error()))
 	}
 	committed = true
 


### PR DESCRIPTION
- BatchUpdateTemplatePermissions 中 errf.Errorf 原先直接将 i18n 翻译结果作为 format 参数传入，翻译文本含 % 占位符时会被误解析， 造成格式化异常或错误信息错乱。统一改为 "%s" 作为 format，将翻译 结果作为实参传入。
- 删除重复的 TemplateRevision().BatchCreateWithTx 错误处理分支。