### PR TITLE
--bug=161543561 fix: 默认模板空间按业务+项目维度判断创建

### DIFF
--- a/cmd/api-server/service/defaultresource.go
+++ b/cmd/api-server/service/defaultresource.go
@@ -13,50 +13,36 @@
 package service
 
 import (
-	"context"
 	"sync"
-
-	"github.com/TencentBlueKing/bk-bscp/pkg/logs"
-	pbbase "github.com/TencentBlueKing/bk-bscp/pkg/protocol/core/base"
 )
 
-// bizsOfTS are bizs which already have default template spaces
-var bizsOfTS BizsOfTmplSpace
+// bizProject 默认模板空间的归属维度：业务 + 项目
+type bizProject struct {
+	bizID     uint32
+	projectID uint32
+}
 
-// BizsOfTmplSpace are bizs which already have default template spaces with a lock which can be used concurrently
+// bizsOfTS are biz+project pairs which already have default template spaces
+var bizsOfTS = BizsOfTmplSpace{pairs: make(map[bizProject]struct{})}
+
+// BizsOfTmplSpace are biz+project pairs which already have default template spaces
+// with a lock which can be used concurrently
 type BizsOfTmplSpace struct {
 	sync.Mutex
-	Bizs map[uint32]struct{}
+	pairs map[bizProject]struct{}
 }
 
-// Set save a key in the bizs map
-func (b *BizsOfTmplSpace) Set(key uint32) {
+// Set save a biz+project pair in the cache
+func (b *BizsOfTmplSpace) Set(bizID, projectID uint32) {
 	b.Lock()
 	defer b.Unlock()
-	b.Bizs[key] = struct{}{}
+	b.pairs[bizProject{bizID: bizID, projectID: projectID}] = struct{}{}
 }
 
-// Has judge if a key in the bizs map
-func (b *BizsOfTmplSpace) Has(key uint32) bool {
+// Has judge if a biz+project pair in the cache
+func (b *BizsOfTmplSpace) Has(bizID, projectID uint32) bool {
 	b.Lock()
 	defer b.Unlock()
-	_, has := b.Bizs[key]
+	_, has := b.pairs[bizProject{bizID: bizID, projectID: projectID}]
 	return has
-}
-
-// initBizsOfTmplSpaces get all bizs which already have default template spaces from db
-func (p *proxy) initBizsOfTmplSpaces() {
-	bizsOfTS.Bizs = make(map[uint32]struct{})
-
-	resp, err := p.cfgClient.GetAllBizsOfTmplSpaces(context.Background(), &pbbase.EmptyReq{})
-	if err != nil {
-		logs.Warnf("init bizs of template spaces from db failed, err: %v", err)
-		return
-	}
-
-	for _, bizID := range resp.BizIds {
-		// no need to use lock for init step
-		bizsOfTS.Bizs[bizID] = struct{}{}
-	}
-	logs.Infof("init bizs of template spaces success, len(biz):%d", len(resp.BizIds))
 }

--- a/cmd/api-server/service/defaultresource_test.go
+++ b/cmd/api-server/service/defaultresource_test.go
@@ -1,0 +1,37 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import "testing"
+
+// TestBizsOfTmplSpace 验证默认模板空间缓存按 业务+项目 组合维度隔离，
+// 避免同业务下新项目因 biz 级缓存命中而跳过默认空间创建。
+func TestBizsOfTmplSpace(t *testing.T) {
+	c := BizsOfTmplSpace{pairs: make(map[bizProject]struct{})}
+
+	if c.Has(1, 100) {
+		t.Fatal("empty cache should not hit")
+	}
+
+	c.Set(1, 100)
+
+	if !c.Has(1, 100) {
+		t.Fatal("set pair should hit")
+	}
+	if c.Has(1, 101) {
+		t.Fatal("same biz with another project should not hit")
+	}
+	if c.Has(2, 100) {
+		t.Fatal("another biz with same project should not hit")
+	}
+}

--- a/cmd/api-server/service/middleware.go
+++ b/cmd/api-server/service/middleware.go
@@ -39,19 +39,20 @@ func (p *proxy) CheckDefaultTmplSpace(next http.Handler) http.Handler {
 			return
 		}
 		bizID := uint32(bizIDInt)
-		if bizsOfTS.Has(bizID) {
+		kt := kit.MustGetKit(r.Context())
+		// 默认模板空间按 业务+项目 维度判断是否已创建，命中缓存直接放行
+		if bizsOfTS.Has(bizID, kt.ProjectID) {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		kt := kit.MustGetKit(r.Context())
 		// create default template space when not existent
-		in := &pbcs.CreateDefaultTmplSpaceReq{BizId: bizID}
+		in := &pbcs.CreateDefaultTmplSpaceReq{BizId: bizID, ProjectId: kt.ProjectID}
 		if _, err := p.cfgClient.CreateDefaultTmplSpace(kt.RpcCtx(), in); err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return
 		}
-		bizsOfTS.Set(bizID)
+		bizsOfTS.Set(bizID, kt.ProjectID)
 
 		next.ServeHTTP(w, r)
 	})

--- a/cmd/api-server/service/proxy.go
+++ b/cmd/api-server/service/proxy.go
@@ -116,8 +116,6 @@ func newProxy(dis serviced.Discover) (*proxy, error) {
 		mc:                  mc,
 	}
 
-	p.initBizsOfTmplSpaces()
-
 	return p, nil
 }
 

--- a/cmd/api-server/service/routers.go
+++ b/cmd/api-server/service/routers.go
@@ -140,6 +140,7 @@ func (p *proxy) routers() http.Handler {
 				})
 				// 模版空间相关
 				r.Route("/template_spaces", func(r chi.Router) {
+					r.Use(p.CheckDefaultTmplSpace) // 没有默认模版空间则创建
 					r.Mount("/", p.cfgSvrMux)
 					r.Route("/{template_space_id}", func(r chi.Router) {
 						r.Use(p.TemplateSpaceProjectVerified) // 校验 TemplateSpace 归属于该项目

--- a/internal/dal/dao/template_space.go
+++ b/internal/dal/dao/template_space.go
@@ -13,9 +13,12 @@
 package dao
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/go-sql-driver/mysql"
 	rawgen "gorm.io/gen"
+	"gorm.io/gorm"
 
 	"github.com/TencentBlueKing/bk-bscp/internal/criteria/constant"
 	"github.com/TencentBlueKing/bk-bscp/internal/dal/gen"
@@ -417,10 +420,28 @@ func (dao *templateSpaceDao) CreateDefault(kit *kit.Kit, bizID, projectID uint32
 		return nil
 	}
 	if err := dao.genQ.Transaction(createTx); err != nil {
+		// 并发场景下多个请求可能同时通过前置查询，template_spaces 的唯一索引
+		// (tenant_id, biz_id, project_id, name) 会让后到的事务报重复键错误；
+		// 此时默认空间已由先到的请求创建成功，按幂等处理回查并返回已有记录
+		if isDuplicateKeyError(err) {
+			tmplSpace, getErr := dao.GetByUniqueKey(kit, bizID, projectID, constant.DefaultTmplSpaceCNName)
+			if getErr == nil {
+				return tmplSpace.ID, nil
+			}
+		}
 		return 0, err
 	}
 
 	return g.ID, nil
+}
+
+// isDuplicateKeyError 判断是否为唯一键冲突错误
+func isDuplicateKeyError(err error) bool {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1062
 }
 
 // GetByUniqueKey get template space by unique key

--- a/internal/dal/dao/template_space_test.go
+++ b/internal/dal/dao/template_space_test.go
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dao
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"gorm.io/gorm"
+)
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "普通错误", err: errors.New("some error"), want: false},
+		{name: "gorm 重复键错误", err: gorm.ErrDuplicatedKey, want: true},
+		{name: "包装后的 gorm 重复键错误", err: fmt.Errorf("wrap: %w", gorm.ErrDuplicatedKey), want: true},
+		{name: "mysql 1062 错误", err: &mysql.MySQLError{Number: 1062, Message: "Duplicate entry"}, want: true},
+		{name: "包装后的 mysql 1062 错误", err: fmt.Errorf("wrap: %w",
+			&mysql.MySQLError{Number: 1062, Message: "Duplicate entry"}), want: true},
+		{name: "其他 mysql 错误", err: &mysql.MySQLError{Number: 1213, Message: "Deadlock found"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDuplicateKeyError(tt.err); got != tt.want {
+				t.Errorf("isDuplicateKeyError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
    原有 CheckDefaultTmplSpace 中间件仅按 biz_id 缓存是否已创建默认模板空间，
    多项目改造后，业务下新建项目会因 biz 级缓存命中而跳过默认空间创建。

    - 缓存 key 由 biz_id 改为 biz_id+project_id 组合，同业务不同项目互不误命中
    - 中间件依据 kt.ProjectID 判断默认空间是否存在，不存在则创建
    - 移除启动预热（GetAllBizsOfTmplSpaces 仅返回 biz 维度无法构建组合 key， 底层 CreateDefault 幂等，改为懒加载）
    - 新增组合 key 缓存单测