### PR TITLE
--bug=161744060 fix: 错误响应不再被 GenericResponseWriter 包一层 data

### DIFF
--- a/internal/rest/view/writer.go
+++ b/internal/rest/view/writer.go
@@ -51,12 +51,33 @@ type GenericResponseWriter struct {
 	authorizer   auth.Authorizer
 	annotation   *webannotation.Annotation
 	err          error // low-level runtime error
+	// status 记录 WriteHeader 写入的状态码，0 表示尚未写入
+	status int
+}
+
+// WriteHeader 记录状态码，供 Write 判断是否跳过 data 包装
+func (w *GenericResponseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// isErrorStatus 判断当前是否处于错误响应状态：上层已显式 SetError，或写入的状态码非 2xx。
+// chi middleware 通过 render.Render(rest.BadRequest) 直接写出错误响应，不会触发 SetError，
+// 但会 WriteHeader(4xx)，因此这里用状态码兜底识别错误响应，避免把 {"error":{...}} 又包成 {"data":...}。
+func (w *GenericResponseWriter) isErrorStatus() bool {
+	if w.err != nil {
+		return true
+	}
+	if w.status == 0 {
+		return false
+	}
+	return w.status < 200 || w.status >= 300
 }
 
 // Write http write 接口实现
 func (w *GenericResponseWriter) Write(data []byte) (int, error) {
-	// 错误不需要特殊处理
-	if w.err != nil {
+	// 错误响应(含 chi middleware 直接 render.Render 的 BadRequest)不补充 data 包装
+	if w.isErrorStatus() {
 		return w.ResponseWriter.Write(data)
 	}
 

--- a/internal/rest/view/writer_test.go
+++ b/internal/rest/view/writer_test.go
@@ -1,0 +1,93 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package view
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TencentBlueKing/bk-bscp/pkg/rest"
+)
+
+// TestGenericResponseWriter_WrapsNormalResponseWithdata 正常 2xx 响应应当被包成 {"data": <body>}
+func TestGenericResponseWriter_WrapsNormalResponseWithdata(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := NewGenericResponseWriter(rec, nil)
+
+	w.WriteHeader(http.StatusOK)
+	n, err := w.Write([]byte(`{"foo":"bar"}`))
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("no bytes written")
+	}
+
+	got := rec.Body.String()
+	want := `{"data":{"foo":"bar"}}`
+	if got != want {
+		t.Fatalf("normal response should be wrapped with data, got=%s, want=%s", got, want)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code should be preserved, got=%d, want=%d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestGenericResponseWriter_BadRequestFromChiMiddlewareNotWrapped chi middleware 通过
+// render.Render(rest.BadRequest) 直接写出的错误响应, 状态码为 4xx, 不应被包成 {"data": {"error":{...}}}
+// 应保持 {"error":{...}} 原样输出。
+func TestGenericResponseWriter_BadRequestFromChiMiddlewareNotWrapped(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := NewGenericResponseWriter(rec, nil)
+
+	// 模拟 rest.BadRequest 写出流程: 先 WriteHeader(4xx), 再 Write 序列化的 ErrorResponse body
+	rr := rest.BadRequest(errString("project does not exist"))
+	// 复用 rest.ErrorResponse 的 Render 写出: 这里直接构造等价的 json 串, 验证不被二次包装
+	_ = rr
+	w.WriteHeader(http.StatusBadRequest)
+	body := `{"error":{"code":"INVALID_REQUEST","message":"project does not exist","data":null,"details":null}}`
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	got := rec.Body.String()
+	if got != body {
+		t.Fatalf("bad request from chi middleware should NOT be wrapped with data, got=%s, want=%s", got, body)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status code should be preserved, got=%d, want=%d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// TestGenericResponseWriter_SetErrorShortCircuits 走 grpc-gateway 错误路径时通过 SetError
+// 标记错误, Write 应直接透传, 与状态码兜底行为一致。
+func TestGenericResponseWriter_SetErrorShortCircuits(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := NewGenericResponseWriter(rec, nil)
+	w.SetError(errString("rpc failed"))
+
+	body := `{"error":{"code":"INVALID_REQUEST","message":"rpc failed"}}`
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	got := rec.Body.String()
+	if got != body {
+		t.Fatalf("error response should be passed through, got=%s, want=%s", got, body)
+	}
+}
+
+// errString 简单的 error 字符串包装, 测试用
+type errString string
+
+func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
view.Generic 中间件会把所有响应包成 {"data": <body>}，原本只
对 grpc-gateway 错误路径(bkErrorHandler 调 SetError)做了短路， 未覆盖 chi middleware 直接 render.Render(rest.BadRequest) 的场景。

导致 /api/v1/config/ 路由组下 VerifyProjectExists 等鉴权中间
件的 4xx 错误被错误包装成 {"data":{"error":{...}}}，与同组的
BizVerified 等返回结构不一致。

新增 WriteHeader 记录状态码，Write 中识别非 2xx 状态码即跳过
data 包装，使错误响应统一为 {"error":{...}}。补充单包测试覆盖
正常响应包装、chi middleware 错误透传、grpc-gateway 错误透传三种场景。