### PR TITLE
--story=137031269 CMDB 同步进程时 proc_num 为 0 归一化为 1

### DIFF
--- a/internal/processor/cmdb/sync_cmdb.go
+++ b/internal/processor/cmdb/sync_cmdb.go
@@ -188,6 +188,7 @@ func (s *syncCMDBService) syncProcessesWithTx(kt *kit.Kit, newProcesses []*table
 	return res, nil
 }
 
+//nolint:unparam // tenantID 在多租户场景下由 getTenantID() 动态返回，单租户部署时恒为 "default" 属预期行为
 func (s *syncCMDBService) buildProcessEntities(kt *kit.Kit, data []*bkcmdb.ProcessRelatedInfoItem, tenantID string) []*table.Process {
 
 	now := time.Now()
@@ -269,7 +270,7 @@ func (s *syncCMDBService) buildProcessEntities(kt *kit.Kit, data []*bkcmdb.Proce
 				InnerIPV6:    item.Host.BkHostInnerIPV6,
 				SourceData:   sourceData,
 				PrevData:     "{}",
-				ProcNum:      uint(item.Process.ProcNum),
+				ProcNum:      normalizeProcNum(item.Process.ProcNum),
 				FuncName:     item.Process.BkFuncName,
 				OsType:       osType,
 				CcSyncStatus: table.Synced,
@@ -333,6 +334,14 @@ func resolveAgentStatus(agentID string, status table.AgentStatus) table.AgentSta
 		return table.AgentStatusAbnormal
 	}
 	return status
+}
+
+// normalizeProcNum 归一化进程数量：CMDB 约定 proc_num 为 0 时按 1 处理
+func normalizeProcNum(n int) uint {
+	if n <= 0 {
+		return 1
+	}
+	return uint(n)
 }
 
 // hostOsTypeKey 主机唯一标识：管控区域 + 内网 IP（CC 通过该组合唯一确定一台主机）
@@ -1049,7 +1058,7 @@ func (s *syncCMDBService) UpdateProcess(ctx context.Context, processes []bkcmdb.
 
 		newSpec := *oldP.Spec
 		newSpec.Alias = p.BkProcessName
-		newSpec.ProcNum = uint(p.ProcNum)
+		newSpec.ProcNum = normalizeProcNum(p.ProcNum)
 		newSpec.SourceData = string(sourceData)
 
 		// 事件不含主机信息，attachment 直接复用 DB 旧值，
@@ -1188,7 +1197,7 @@ func buildProcessesFromSets(tenantID string, bizID int, sets []Set) []*table.Pro
 							ProcessStateSyncedAt: nil,
 							SourceData:           sourceData,
 							PrevData:             "{}",
-							ProcNum:              uint(proc.ProcNum),
+							ProcNum:              normalizeProcNum(proc.ProcNum),
 							FuncName:             proc.FuncName,
 							OsType:               h.OsType,
 							AgentStatus:          resolveAgentStatus(h.AgentID, table.AgentStatus(h.AgentState)),

--- a/internal/processor/cmdb/sync_cmdb_procnum_test.go
+++ b/internal/processor/cmdb/sync_cmdb_procnum_test.go
@@ -1,0 +1,95 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmdb
+
+import (
+	"testing"
+
+	"github.com/TencentBlueKing/bk-bscp/internal/components/bkcmdb"
+	"github.com/TencentBlueKing/bk-bscp/pkg/kit"
+)
+
+// TestNormalizeProcNum 校验 CMDB proc_num 为 0 时归一化为 1
+func TestNormalizeProcNum(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want uint
+	}{
+		{"zero to one", 0, 1},
+		{"one stays one", 1, 1},
+		{"two stays two", 2, 2},
+		{"large value", 100, 100},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := normalizeProcNum(c.in); got != c.want {
+				t.Fatalf("normalizeProcNum(%d) = %d, want %d", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestBuildProcessEntitiesNormalizesProcNum 校验 buildProcessEntities（新同步链路）
+// 在 CMDB proc_num 为 0 时归一化为 1
+func TestBuildProcessEntitiesNormalizesProcNum(t *testing.T) {
+	svc := &osTypeStubCMDB{}
+	s := &syncCMDBService{bizID: 3, svc: svc}
+	kt := kit.New()
+
+	item := newOsTypeProcessItem(0, "127.0.0.1")
+	item.Process.ProcNum = 0
+	data := []*bkcmdb.ProcessRelatedInfoItem{item}
+
+	procs := s.buildProcessEntities(kt, data, "default")
+
+	if len(procs) != 1 {
+		t.Fatalf("processes count = %d, want 1", len(procs))
+	}
+	if got := procs[0].Spec.ProcNum; got != 1 {
+		t.Fatalf("ProcNum = %d, want 1 (normalized from 0)", got)
+	}
+}
+
+// TestBuildProcessesFromSetsNormalizesProcNum 校验 buildProcessesFromSets（旧同步链路）
+// 在 CMDB proc_num 为 0 时归一化为 1
+func TestBuildProcessesFromSetsNormalizesProcNum(t *testing.T) {
+	sets := []Set{
+		{
+			ID: 1, Name: "set1", SetEnv: "1",
+			Module: []Module{
+				{
+					ID: 10, Name: "module1",
+					Host: []Host{{ID: 100, IP: "127.0.0.1"}},
+					SvcInst: []SvcInst{
+						{
+							ID: 1, Name: "svc1",
+							ProcInst: []ProcInst{
+								{ID: 1000, HostID: 100, Name: "proc1", ProcNum: 0},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	procs := buildProcessesFromSets("default", 3, sets)
+
+	if len(procs) != 1 {
+		t.Fatalf("processes count = %d, want 1", len(procs))
+	}
+	if got := procs[0].Spec.ProcNum; got != 1 {
+		t.Fatalf("ProcNum = %d, want 1 (normalized from 0)", got)
+	}
+}


### PR DESCRIPTION
CMDB 约定 proc_num 为 0 时业务上表示 1 个进程实例。此前同步时
直接使用原始值，proc_num=0 会导致进程实例不被创建，与业务语义不符。

新增 normalizeProcNum 辅助函数，统一在以下链路入口归一化处理：
- buildProcessEntities（新同步/增量同步/进程创建事件）
- UpdateProcess（进程更新事件）
- buildProcessesFromSets（旧同步全量/增量）

补充单测覆盖 proc_num=0 场景。