### PR TITLE
--bug=162439968 fix: 修复 not_tag 过滤条件中 OR 优先级导致 name 过滤失效的问题

### DIFF
--- a/internal/dal/dao/hook.go
+++ b/internal/dal/dao/hook.go
@@ -130,7 +130,8 @@ func (dao *hookDao) CountNumberUnReferences(kit *kit.Kit, bizID, projectID uint3
 	} else if opt.NotTag {
 		// when the length of tags is 2, it must be '[]'
 		// It could also be null
-		q = q.Where(h.Tags.Length().Eq(2)).Or(h.Tags.Length().Eq(4))
+		// Where 内嵌表示括号, 否则 Or 会绕过前面的过滤条件
+		q = q.Where(q.Where(h.Tags.Length().Eq(2)).Or(h.Tags.Length().Eq(4)))
 	}
 
 	return q.LeftJoin(rh, h.ID.EqCol(rh.HookID)).Where(rh.HookID.IsNull()).Count()
@@ -214,7 +215,8 @@ func (dao *hookDao) ListWithRefer(kit *kit.Kit, opt *types.ListHooksWithReferOpt
 	} else if opt.NotTag {
 		// when the length of tags is 2, it must be '[]'
 		// It could also be null
-		q = q.Where(h.Tags.Length().Eq(2)).Or(h.Tags.Length().Eq(4))
+		// Where 内嵌表示括号, 否则 Or 会绕过前面的过滤条件
+		q = q.Where(q.Where(h.Tags.Length().Eq(2)).Or(h.Tags.Length().Eq(4)))
 	}
 
 	if opt.SearchKey != "" {


### PR DESCRIPTION
ListWithRefer 与 CountNumberUnReferences 在处理 not_tag=true 时， Where(tags.length=2).Or(tags.length=4) 未加括号，SQL 中 AND 优先级 高于 OR，导致 OR 分支绕过 name（及 biz/project）过滤，查询 name
匹配不到时仍返回不相关数据。

使用嵌套 Where 将 OR 条件整体包裹，生成 (length=2 OR length=4)
带括号条件，保证 name 过滤始终生效。