### PR TITLE
--bug=162543053 fix: 业务模板空间列表过滤 config_delivery 全局共享空间

### DIFF
--- a/cmd/data-service/service/template_set.go
+++ b/cmd/data-service/service/template_set.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/TencentBlueKing/bk-bscp/internal/search"
+	"github.com/TencentBlueKing/bk-bscp/pkg/criteria/constant"
 	"github.com/TencentBlueKing/bk-bscp/pkg/criteria/errf"
 	"github.com/TencentBlueKing/bk-bscp/pkg/dal/table"
 	"github.com/TencentBlueKing/bk-bscp/pkg/i18n"
@@ -506,6 +507,12 @@ func (s *Service) ListTmplSetsOfBiz(ctx context.Context, req *pbds.ListTmplSetsO
 
 	details := make([]*pbtset.TemplateSetOfBizDetail, 0)
 	for _, t := range tmplSpaces {
+		// 业务级共享的系统内置空间 config_delivery（project_id 固定为 0）服务于进程配置管理，
+		// 产品上不引入项目维度，不在此业务模板空间列表中返回，不影响其他空间。
+		if t.Spec.Name == constant.CONFIG_DELIVERY && t.Attachment.ProjectID == constant.GlobalProjectID {
+			delete(tmplSetsMap, t.ID)
+			continue
+		}
 		details = append(details, &pbtset.TemplateSetOfBizDetail{
 			TemplateSpaceId:   t.ID,
 			TemplateSpaceName: t.Spec.Name,

--- a/internal/dal/dao/template_space.go
+++ b/internal/dal/dao/template_space.go
@@ -268,6 +268,8 @@ func (dao *templateSpaceDao) List(kit *kit.Kit, bizID, projectID uint32, s searc
 		}
 	}
 
+	// 业务级共享的系统内置空间 config_delivery（project_id 固定为 0，服务于进程配置管理，
+	// 产品上不引入项目维度）不在此业务模板空间列表中返回，避免污染业务空间列表，不影响其他空间。
 	conds = append(conds, m.Name.Neq(cs.CONFIG_DELIVERY))
 
 	d := q.Where(m.BizID.Eq(bizID), m.ProjectID.Eq(projectID)).Where(conds...).Order(m.Name)


### PR DESCRIPTION
- ListTmplSetsOfBiz 接口过滤 name=config_delivery 且 project_id=0 的系统内置空间， 避免业务级共享空间污染业务模板空间列表，不影响其他空间
- 为 TemplateSpace DAO List 已有的 Name.Neq(config_delivery) 排除逻辑补充中文注释说明意图