### PR TITLE
--bug=162600483 fix: 补全模板绑定关系查询的 ProjectId 解析

### DIFF
--- a/cmd/config-server/service/template_binding_relation.go
+++ b/cmd/config-server/service/template_binding_relation.go
@@ -446,6 +446,7 @@ func (s *Service) ListMultiTmplSetBoundUnnamedApps(ctx context.Context, req *pbc
 		Start:           req.Start,
 		Limit:           req.Limit,
 		All:             req.All,
+		ProjectId:       grpcKit.ResolvedProjectID(req.ProjectId),
 	}
 
 	rp, err := s.client.DS.ListMultiTmplSetBoundUnnamedApps(grpcKit.RpcCtx(), r)

--- a/cmd/data-service/service/template_binding_relation.go
+++ b/cmd/data-service/service/template_binding_relation.go
@@ -918,10 +918,8 @@ func (s *Service) ListTmplSetBoundUnnamedApps(ctx context.Context, req *pbds.Lis
 }
 
 // ListMultiTmplSetBoundUnnamedApps list template set bound unnamed app details.
-//
 // nolint:funlen
 func (s *Service) ListMultiTmplSetBoundUnnamedApps(ctx context.Context, req *pbds.ListMultiTmplSetBoundUnnamedAppsReq) (
-
 	*pbds.ListMultiTmplSetBoundUnnamedAppsResp, error) {
 	kt := kit.FromGrpcContext(ctx)
 


### PR DESCRIPTION
- 在 config-server 调用 data-service 的 ListMultiTmplSetBoundUnnamedApps 时补充 ProjectId 的 ResolvedProjectID 解析，确保项目维度正确传递；
- 同步清理 data-service 中冗余注释与格式。