### PR TITLE
--bug=162596126 fix: KV 密码类型增加复杂度校验

### DIFF
--- a/cmd/config-server/service/kv.go
+++ b/cmd/config-server/service/kv.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
@@ -101,7 +102,15 @@ func (s *Service) UpdateKv(ctx context.Context, req *pbcs.UpdateKvReq) (*pbcs.Up
 		return nil, err
 	}
 
-	expirationTime, err := verifySecretVaule(grpcKit, req.SecretType, req.Key, req.Value)
+	// 编辑请求通常不携带 secret_type（如 UI 编辑仅提交 value/memo/secret_hidden），
+	// 而 data-service 更新时会保留存量 KV 的密钥类型，因此需要以存量密钥类型校验新值，
+	// 避免已存在的密码类型 KV 被更新为不满足复杂度要求的弱密码。
+	secretType, err := s.kvSecretTypeForUpdate(grpcKit, req.BizId, req.AppId, req.Key, req.SecretType)
+	if err != nil {
+		return nil, err
+	}
+
+	expirationTime, err := verifySecretVaule(grpcKit, secretType, req.Key, req.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +135,34 @@ func (s *Service) UpdateKv(ctx context.Context, req *pbcs.UpdateKvReq) (*pbcs.Up
 
 	return &pbcs.UpdateKvResp{}, nil
 
+}
+
+// kvSecretTypeForUpdate 获取更新 KV 时用于校验新值的密钥类型。
+// data-service 更新 KV 时不修改密钥类型（保留存量值），因此校验必须基于存量密钥类型；
+// 仅当存量 KV 不存在时回退到请求携带的类型（此时更新会在 data-service 因记录不存在而失败）。
+func (s *Service) kvSecretTypeForUpdate(kit *kit.Kit, bizID, appID uint32, key, reqSecretType string) (
+	string, error) {
+
+	rp, err := s.client.DS.ListKvs(kit.RpcCtx(), &pbds.ListKvsReq{
+		BizId:      bizID,
+		AppId:      appID,
+		Key:        []string{key},
+		All:        true,
+		WithStatus: true,
+		Status:     []string{constant.FileStateAdd, constant.FileStateRevise, constant.FileStateUnchange},
+	})
+	if err != nil {
+		logs.Errorf("list kv failed, err: %v, rid: %s", err, kit.Rid)
+		return "", err
+	}
+
+	for _, kv := range rp.GetDetails() {
+		if kv.GetSpec().GetKey() == key {
+			return kv.GetSpec().GetSecretType(), nil
+		}
+	}
+
+	return reqSecretType, nil
 }
 
 // ListKvs is used to list key-value data.
@@ -796,6 +833,15 @@ func verifySecretVaule(kit *kit.Kit, secretType, key, value string) (string, err
 		return "", errors.New(i18n.T(kit, `please fill in the value of configuration item %s first`, key))
 	}
 
+	// 密码类型需要校验复杂度：至少包含大写字母、小写字母、数字、特殊字符中的 3 种
+	if secretType == string(table.SecretTypePassword) {
+		if err := validatePasswordComplexity(value); err != nil {
+			return "", errors.New(i18n.T(kit, `the password of configuration item %s is not complex enough, `+
+				`it must contain at least 3 types of the following: uppercase letters, lowercase letters, `+
+				`numbers and special characters`, key))
+		}
+	}
+
 	expirationTime, err := validatePemContent(value)
 	if secretType == string(table.SecretTypeCertificate) && err != nil {
 		return "", errors.New(i18n.T(kit,
@@ -803,6 +849,42 @@ func verifySecretVaule(kit *kit.Kit, secretType, key, value string) (string, err
 	}
 
 	return expirationTime, nil
+}
+
+// validatePasswordComplexity 校验密码复杂度，要求至少包含大写字母、小写字母、数字、特殊字符中的 3 种。
+func validatePasswordComplexity(password string) error {
+	var hasUpper, hasLower, hasDigit, hasSpecial bool
+	for _, r := range password {
+		switch {
+		case unicode.IsUpper(r):
+			hasUpper = true
+		case unicode.IsLower(r):
+			hasLower = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		case unicode.IsPunct(r) || unicode.IsSymbol(r):
+			hasSpecial = true
+		}
+	}
+
+	types := 0
+	if hasUpper {
+		types++
+	}
+	if hasLower {
+		types++
+	}
+	if hasDigit {
+		types++
+	}
+	if hasSpecial {
+		types++
+	}
+
+	if types < 3 {
+		return errors.New("password complexity is too low")
+	}
+	return nil
 }
 
 // BatchUnDeleteKv 批量恢复删除的kv


### PR DESCRIPTION
- 在 verifySecretVaule 中对 secret_type=password 增加校验：值须至少包含大写字母、小写字母、数字、特殊字符中的 3 种。
- 覆盖所有写入入口：CreateKv、UpdateKv、BatchUpsertKvs、ImportKvs（均经 verifySecretVaule）。