### PR TITLE
--bug=162439968 fix: 修复 hook 列表查询跨业务数据泄漏问题

### DIFF
--- a/internal/dal/dao/hook.go
+++ b/internal/dal/dao/hook.go
@@ -18,6 +18,7 @@ import (
 
 	"gorm.io/datatypes"
 	rawgen "gorm.io/gen"
+	"gorm.io/gen/field"
 
 	"github.com/TencentBlueKing/bk-bscp/internal/criteria/constant"
 	"github.com/TencentBlueKing/bk-bscp/internal/dal/gen"
@@ -130,8 +131,9 @@ func (dao *hookDao) CountNumberUnReferences(kit *kit.Kit, bizID, projectID uint3
 	} else if opt.NotTag {
 		// when the length of tags is 2, it must be '[]'
 		// It could also be null
-		// Where 内嵌表示括号, 否则 Or 会绕过前面的过滤条件
-		q = q.Where(q.Where(h.Tags.Length().Eq(2)).Or(h.Tags.Length().Eq(4)))
+		// field.Or 整体生成带括号的 OR 条件, 嵌套 q.Where(...).Or(...) 会生成无括号的
+		// AND/OR 混合 SQL, AND 优先级高于 OR, 导致绕过 biz/project 过滤条件
+		q = q.Where(field.Or(h.Tags.Length().Eq(2), h.Tags.Length().Eq(4)))
 	}
 
 	return q.LeftJoin(rh, h.ID.EqCol(rh.HookID)).Where(rh.HookID.IsNull()).Count()
@@ -215,16 +217,21 @@ func (dao *hookDao) ListWithRefer(kit *kit.Kit, opt *types.ListHooksWithReferOpt
 	} else if opt.NotTag {
 		// when the length of tags is 2, it must be '[]'
 		// It could also be null
-		// Where 内嵌表示括号, 否则 Or 会绕过前面的过滤条件
-		q = q.Where(q.Where(h.Tags.Length().Eq(2)).Or(h.Tags.Length().Eq(4)))
+		// field.Or 整体生成带括号的 OR 条件, 嵌套 q.Where(...).Or(...) 会生成无括号的
+		// AND/OR 混合 SQL, AND 优先级高于 OR, 导致绕过 biz/project 过滤条件
+		q = q.Where(field.Or(h.Tags.Length().Eq(2), h.Tags.Length().Eq(4)))
 	}
 
 	if opt.SearchKey != "" {
 		searchKey := "(?i)" + opt.SearchKey
-		// Where 内嵌表示括号, 例如: q.Where(q.Where(a).Or(b)) => (a or b)
-		// 参考: https://gorm.io/zh_CN/gen/query.html#Group-%E6%9D%A1%E4%BB%B6
-		q = q.Where(q.Where(h.Name.Regexp(searchKey)).Or(h.Memo.Regexp(searchKey)).Or(
-			h.Creator.Regexp(searchKey)).Or(h.Reviser.Regexp(searchKey)))
+		// field.Or 整体生成带括号的 OR 条件, 嵌套 q.Where(...).Or(...) 会生成无括号的
+		// AND/OR 混合 SQL, AND 优先级高于 OR, 导致绕过 biz/project 过滤条件
+		q = q.Where(field.Or(
+			h.Name.Regexp(searchKey),
+			h.Memo.Regexp(searchKey),
+			h.Creator.Regexp(searchKey),
+			h.Reviser.Regexp(searchKey),
+		))
 	}
 
 	details := make([]*types.ListHooksWithReferDetail, 0)
@@ -270,10 +277,13 @@ func (dao *hookDao) ListHookReferences(kit *kit.Kit, opt *types.ListHookReferenc
 		Where(rh.HookID.Eq(opt.HookID), rh.BizID.Eq(opt.BizID))
 	if opt.SearchKey != "" {
 		searchKey := "(?i)" + opt.SearchKey
-		// Where 内嵌表示括号, 例如: q.Where(q.Where(a).Or(b)) => (a or b)
-		// 参考: https://gorm.io/zh_CN/gen/query.html#Group-%E6%9D%A1%E4%BB%B6
-		query = query.Where(query.Where(
-			a.Name.Regexp(searchKey)).Or(r.Name.Regexp(searchKey)).Or(rh.HookRevisionName.Regexp(searchKey)))
+		// field.Or 整体生成带括号的 OR 条件, 嵌套 query.Where(...).Or(...) 会生成无括号的
+		// AND/OR 混合 SQL, AND 优先级高于 OR, 导致绕过 hook/biz 过滤条件
+		query = query.Where(field.Or(
+			a.Name.Regexp(searchKey),
+			r.Name.Regexp(searchKey),
+			rh.HookRevisionName.Regexp(searchKey),
+		))
 	}
 
 	count, err = query.Order(rh.ID.Desc()).ScanByPage(&details, opt.Page.Offset(), opt.Page.LimitInt())

--- a/internal/dal/dao/hook_revision.go
+++ b/internal/dal/dao/hook_revision.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	rawgen "gorm.io/gen"
+	"gorm.io/gen/field"
 
 	"github.com/TencentBlueKing/bk-bscp/internal/criteria/constant"
 	"github.com/TencentBlueKing/bk-bscp/internal/dal/gen"
@@ -308,10 +309,13 @@ func (dao *hookRevisionDao) ListHookRevisionReferences(kit *kit.Kit, opt *types.
 
 	if opt.SearchKey != "" {
 		searchKey := "(?i)" + opt.SearchKey
-		// Where 内嵌表示括号, 例如: q.Where(q.Where(a).Or(b)) => (a or b)
-		// 参考: https://gorm.io/zh_CN/gen/query.html#Group-%E6%9D%A1%E4%BB%B6
-		query = query.Where(query.Where(
-			a.Name.Regexp(searchKey)).Or(r.Name.Regexp(searchKey)).Or(rh.HookRevisionName.Regexp(searchKey)))
+		// field.Or 整体生成带括号的 OR 条件, 嵌套 query.Where(...).Or(...) 会生成无括号的
+		// AND/OR 混合 SQL, AND 优先级高于 OR, 导致绕过 hook/biz 过滤条件
+		query = query.Where(field.Or(
+			a.Name.Regexp(searchKey),
+			r.Name.Regexp(searchKey),
+			rh.HookRevisionName.Regexp(searchKey),
+		))
 	}
 
 	count, err = query.Order(rh.ID.Desc()).ScanByPage(&details, opt.Page.Offset(), opt.Page.LimitInt())


### PR DESCRIPTION
内嵌 q.Where(q.Where(a).Or(b)) 写法在 gorm gen v0.3.23 中不生成括号, AND 优先级高于 OR 导致绕过 biz/project 过滤条件, 其他业务匹配搜索词
或空标签的数据被查出。改用 field.Or(...) 生成带括号的整体 OR 条件。

- ListWithRefer/ListHookReferences 的 SearchKey、NotTag 分支
- CountNumberUnReferences 的 NotTag 分支
- hook_revision.go ListHookRevisionReferences 的 SearchKey