### PR TITLE
fix: 修复 uint32 收窄溢出风险并修正 app-id 锁键作用域

### DIFF
--- a/cmd/api-server/service/middleware.go
+++ b/cmd/api-server/service/middleware.go
@@ -33,12 +33,13 @@ import (
 func (p *proxy) CheckDefaultTmplSpace(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bizIDStr := chi.URLParam(r, "biz_id")
-		bizIDInt, err := strconv.Atoi(bizIDStr)
+		// ParseUint 限定 32 位无符号范围，避免 int 到 uint32 转换时的静默截断
+		bizID64, err := strconv.ParseUint(bizIDStr, 10, 32)
 		if err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return
 		}
-		bizID := uint32(bizIDInt)
+		bizID := uint32(bizID64)
 		kt := kit.MustGetKit(r.Context())
 		// 默认模板空间按 业务+项目 维度判断是否已创建，命中缓存直接放行
 		if bizsOfTS.Has(bizID, kt.ProjectID) {
@@ -148,27 +149,31 @@ func (p *proxy) AppProjectEnvVerified(next http.Handler) http.Handler {
 			return
 		}
 
-		appID, err := strconv.Atoi(appIDStr)
+		// ParseUint 限定 32 位无符号范围，避免 int 到 uint32 转换时的静默截断
+		appID, err := strconv.ParseUint(appIDStr, 10, 32)
 		if err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return
 		}
 
+		// ParseUint(bitSize=32) 已确保 appID 落在 uint32 范围内，收窄转换安全。
+		appID32 := uint32(appID)
+
 		// 调用 config-server GetApp 校验 App 归属于该项目+环境
 		_, err = p.cfgClient.GetApp(kt.RpcCtx(), &pbcs.GetAppReq{
 			BizId:     kt.BizID,
-			AppId:     uint32(appID),
+			AppId:     appID32,
 			ProjectId: kt.ProjectID,
 			EnvId:     kt.EnvID,
 		})
 		if err != nil {
 			logs.Errorf("verify app project/env failed, bizId=%d appId=%d projectId=%d envId=%d err=%v rid=%s",
-				kt.BizID, uint32(appID), kt.ProjectID, kt.EnvID, err, kt.Rid)
+				kt.BizID, appID32, kt.ProjectID, kt.EnvID, err, kt.Rid)
 			render.Render(w, r, rest.BadRequest(fmt.Errorf("app does not belong to the specified project or environment")))
 			return
 		}
 
-		kt.AppID = uint32(appID)
+		kt.AppID = appID32
 
 		next.ServeHTTP(w, r)
 	})
@@ -188,21 +193,24 @@ func (p *proxy) HookProjectVerified(next http.Handler) http.Handler {
 			return
 		}
 
-		hookID, err := strconv.Atoi(hookIDStr)
+		hookID, err := strconv.ParseUint(hookIDStr, 10, 32)
 		if err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return
 		}
 
+		// ParseUint(bitSize=32) 已确保 hookID 落在 uint32 范围内，收窄转换安全。
+		hookID32 := uint32(hookID)
+
 		// 调用 config-server GetHook 校验 Hook 归属于该项目
 		_, err = p.cfgClient.GetHook(kt.RpcCtx(), &pbcs.GetHookReq{
 			BizId:     kt.BizID,
 			ProjectId: kt.ProjectID,
-			HookId:    uint32(hookID),
+			HookId:    hookID32,
 		})
 		if err != nil {
 			logs.Errorf("verify hook project failed, bizId=%d hookId=%d projectId=%d err=%v rid=%s",
-				kt.BizID, uint32(hookID), kt.ProjectID, err, kt.Rid)
+				kt.BizID, hookID32, kt.ProjectID, err, kt.Rid)
 			render.Render(w, r, rest.BadRequest(fmt.Errorf("hook does not belong to the specified project")))
 			return
 		}
@@ -226,7 +234,7 @@ func (p *proxy) GroupProjectVerified(next http.Handler) http.Handler {
 			return
 		}
 
-		groupID, err := strconv.Atoi(groupIDStr)
+		groupID, err := strconv.ParseUint(groupIDStr, 10, 32)
 		if err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return
@@ -265,7 +273,7 @@ func (p *proxy) TemplateSpaceProjectVerified(next http.Handler) http.Handler {
 			return
 		}
 
-		templateSpaceID, err := strconv.Atoi(templateSpaceIDStr)
+		templateSpaceID, err := strconv.ParseUint(templateSpaceIDStr, 10, 32)
 		if err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return
@@ -303,7 +311,7 @@ func (p *proxy) TemplateVariableProjectVerified(next http.Handler) http.Handler 
 			return
 		}
 
-		templateVarID, err := strconv.Atoi(templateVarIDStr)
+		templateVarID, err := strconv.ParseUint(templateVarIDStr, 10, 32)
 		if err != nil {
 			render.Render(w, r, rest.BadRequest(err))
 			return

--- a/cmd/cache-service/service/cache/client/app.go
+++ b/cmd/cache-service/service/cache/client/app.go
@@ -53,7 +53,9 @@ func (c *client) GetAppID(kt *kit.Kit, bizID, projectID, envID uint32, appName s
 	}
 
 	// do not find app in the cache, then try get from db directly.
-	state := c.rLock.Acquire(keys.ResKind.AppID(bizID, appName))
+	// 锁键与缓存键使用相同的 project/env 作用域维度，避免不同项目/环境下的同名应用
+	// 争抢同一把刷新锁，导致后到请求读取自己的作用域键未命中而误报 RecordNotFound。
+	state := c.rLock.Acquire(keys.ResKind.AppID(bizID, projectID, envID, appName))
 	if state.Acquired || (!state.Acquired && state.WithLimit) {
 		start := time.Now()
 		appID, err = c.refreshAppIDCache(kt, bizID, projectID, envID, appName)

--- a/cmd/cache-service/service/cache/keys/cache_test.go
+++ b/cmd/cache-service/service/cache/keys/cache_test.go
@@ -37,6 +37,20 @@ func TestAppIDKeyIsolation(t *testing.T) {
 	}
 }
 
+// TestAppIDLockKeyIsolation 验证 app-id 刷新锁键与缓存键使用相同的 project/env 作用域维度，
+// 避免不同项目/环境下的同名应用争抢同一把锁导致误报 RecordNotFound。
+func TestAppIDLockKeyIsolation(t *testing.T) {
+	if ResKind.AppID(1, 2, 3, "app") == ResKind.AppID(1, 2, 4, "app") {
+		t.Fatal("app id lock key collides across envs")
+	}
+	if ResKind.AppID(1, 2, 3, "app") == ResKind.AppID(1, 3, 3, "app") {
+		t.Fatal("app id lock key collides across projects")
+	}
+	if ResKind.AppID(1, 2, 3, "app") != "app-id-1-2-3-app" {
+		t.Fatalf("unexpected app id lock key format, got: %s", ResKind.AppID(1, 2, 3, "app"))
+	}
+}
+
 // TestCredentialKeyIsolation 验证 credential 缓存 key 带项目维度，且维度为零时保持旧格式。
 func TestCredentialKeyIsolation(t *testing.T) {
 	legacy := Key.Credential(1, 0, "tk")

--- a/cmd/cache-service/service/cache/keys/lock.go
+++ b/cmd/cache-service/service/cache/keys/lock.go
@@ -19,9 +19,11 @@ var ResKind = resKind("resource-kind")
 
 type resKind string
 
-// AppID return the app id's resource kind
-func (rk resKind) AppID(bizID uint32, appName string) string {
-	return fmt.Sprintf("app-id-%d-%s", bizID, appName)
+// AppID return the app id's resource kind, scoped by project and env to match
+// the app id cache key's dimensions, so that same-name apps under different
+// projects/envs do not contend for the same refresh lock.
+func (rk resKind) AppID(bizID, projectID, envID uint32, appName string) string {
+	return fmt.Sprintf("app-id-%d-%d-%d-%s", bizID, projectID, envID, appName)
 }
 
 // TenantID return the tenant id's resource kind

--- a/cmd/feed-server/service/service.go
+++ b/cmd/feed-server/service/service.go
@@ -307,8 +307,8 @@ func (s *Service) DownloadFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bizIdStr := chi.URLParam(r, "biz_id")
-	bizID, _ := strconv.Atoi(bizIdStr)
-	if bizID == 0 {
+	bizID, err := strconv.ParseUint(bizIdStr, 10, 32)
+	if err != nil {
 		render.Render(w, r, rest.BadRequest(errors.New("biz id is required")))
 		return
 	}
@@ -334,8 +334,8 @@ func (s *Service) DownloadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.bll.AppCache().EnsureTenantID(kt, uint32(bizID)); err != nil {
-		render.Render(w, r, rest.BadRequest(fmt.Errorf("ensure tenant id for biz %d failed: %v", bizID, err)))
+	if errE := s.bll.AppCache().EnsureTenantID(kt, uint32(bizID)); errE != nil {
+		render.Render(w, r, rest.BadRequest(fmt.Errorf("ensure tenant id for biz %d failed: %v", bizID, errE)))
 		return
 	}
 
@@ -347,13 +347,13 @@ func (s *Service) DownloadFile(w http.ResponseWriter, r *http.Request) {
 	hasEnvPathParam := false
 	if p := chi.URLParam(r, "project_id"); p != "" {
 		hasProjectPathParam = true
-		if pid, err := strconv.ParseUint(p, 10, 32); err == nil {
+		if pid, errP := strconv.ParseUint(p, 10, 32); errP == nil {
 			projectID = uint32(pid)
 		}
 	}
 	if e := chi.URLParam(r, "env_id"); e != "" {
 		hasEnvPathParam = true
-		if eid, err := strconv.ParseUint(e, 10, 32); err == nil {
+		if eid, errE := strconv.ParseUint(e, 10, 32); errE == nil {
 			envID = uint32(eid)
 		}
 	}

--- a/internal/dal/dao/iam.go
+++ b/internal/dal/dao/iam.go
@@ -64,7 +64,7 @@ func (r *iamDao) ListInstances(kt *kit.Kit, opts *types.ListInstancesOption) (
 	)
 	switch opts.ResourceType {
 	case meta.App.String():
-		bizID, err := strconv.Atoi(opts.ParentID)
+		bizID, err := strconv.ParseUint(opts.ParentID, 10, 32)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -124,7 +124,7 @@ func FromGrpcContext(ctx context.Context) *Kit {
 
 	bizIDs := md[lowBizIDKey]
 	if len(bizIDs) != 0 {
-		bizID, err := strconv.ParseUint(bizIDs[0], 10, 64)
+		bizID, err := strconv.ParseUint(bizIDs[0], 10, 32)
 		if err != nil {
 			klog.ErrorS(err, "parse lowBizID %s", bizIDs[0])
 		} else {
@@ -133,7 +133,7 @@ func FromGrpcContext(ctx context.Context) *Kit {
 	}
 	appIDs := md[lowAppIDKey]
 	if len(appIDs) != 0 {
-		appID, err := strconv.ParseUint(appIDs[0], 10, 64)
+		appID, err := strconv.ParseUint(appIDs[0], 10, 32)
 		if err != nil {
 			klog.ErrorS(err, "parse lowBizID %s", appIDs[0])
 		} else {
@@ -143,7 +143,7 @@ func FromGrpcContext(ctx context.Context) *Kit {
 
 	projectIDs := md[lowProjectIDKey]
 	if len(projectIDs) != 0 {
-		projectID, err := strconv.ParseUint(projectIDs[0], 10, 64)
+		projectID, err := strconv.ParseUint(projectIDs[0], 10, 32)
 		if err != nil {
 			klog.ErrorS(err, "parse lowProjectID %s", projectIDs[0])
 		} else {
@@ -153,7 +153,7 @@ func FromGrpcContext(ctx context.Context) *Kit {
 
 	envIDs := md[lowEnvKey]
 	if len(envIDs) != 0 {
-		envID, err := strconv.ParseUint(envIDs[0], 10, 64)
+		envID, err := strconv.ParseUint(envIDs[0], 10, 32)
 		if err != nil {
 			klog.ErrorS(err, "parse lowEnvID %s", envIDs[0])
 		} else {


### PR DESCRIPTION
- kit/iam/feed-server/api-server: 将 strconv.Atoi/ParseUint 解析统一指定 32 位 上限，或在解析后立即收窄为 uint32，消除 int->uint32 静默截断(G115)。
- cache: app-id 刷新锁键纳入 project/env 维度，与缓存键作用域一致，避免不同 项目/环境下同名应用争抢同一把锁导致误报 RecordNotFound，并新增隔离单测。