### PR TITLE
--story=137357658 feat: 补充新旧 UI 互跳 URL 配置

### DIFF
--- a/cmd/ui/service/web.go
+++ b/cmd/ui/service/web.go
@@ -192,6 +192,8 @@ func (s *WebServer) subRouter() http.Handler {
 		NodeManHost:          config.G.Frontend.Host.BKNODEMANHOST,
 		UserManHost:          config.G.Frontend.Host.UserManHost,
 		UserCenterURL:        config.G.Frontend.Host.UserCenterURL,
+		NewUIURL:             config.G.Frontend.Host.NewUIURL,
+		OldUIURL:             config.G.Frontend.Host.OldUIURL,
 	}
 
 	if shouldProxyAPI {

--- a/docs/config/example/bk-bscp-ui.yaml
+++ b/docs/config/example/bk-bscp-ui.yaml
@@ -38,5 +38,9 @@ frontend_conf:
     user_man_host: "[bkapi url]"
     # 用户中心(个人中心)跳转地址, 仅多租户环境配置, 填写完整 URL
     user_center_url: "[bkuser url]/personal-center"
+    # 新 UI 路径/地址, 用于跳转到新 UI 页面; 也可通过环境变量 BK_BSCP_NEW_UI_URL 配置(为空时生效)
+    new_ui_url: ""
+    # 旧 UI 路径/地址, 用于跳转回旧 UI 页面; 也可通过环境变量 BK_BSCP_OLD_UI_URL 配置(为空时生效)
+    old_ui_url: ""
   helper: "[helper]"
   enable_bk_notice: false

--- a/embed.go
+++ b/embed.go
@@ -83,6 +83,8 @@ type IndexConfig struct {
 	NodeManHost          string
 	UserManHost          string
 	UserCenterURL        string // 用户中心(个人中心)跳转地址, 仅多租户环境配置
+	NewUIURL             string // 新 UI 路径/地址, 用于跳转到新 UI 页面
+	OldUIURL             string // 旧 UI 路径/地址, 用于跳转回旧 UI 页面
 }
 
 // EmbedWebServer 前端 web server
@@ -215,6 +217,8 @@ func (e *EmbedWeb) RenderIndexHandler(conf *IndexConfig) http.Handler {
 			"BK_NODE_HOST":              conf.NodeManHost,
 			"USER_MAN_HOST":             conf.UserManHost,
 			"USER_CENTER_URL":           conf.UserCenterURL,
+			"NEW_UI_URL":                conf.NewUIURL,
+			"OLD_UI_URL":                conf.OldUIURL,
 		}
 
 		// 本地开发模式 / 代理请求

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,8 @@ func (c *Configuration) init() error {
 	if err := c.Web.init(); err != nil {
 		return err
 	}
+	c.Frontend.Host.getFromEnv()
+
 	if err := c.Frontend.initResBaseJSURL(c.Base.AppCode); err != nil {
 		return err
 	}

--- a/pkg/config/frontend.go
+++ b/pkg/config/frontend.go
@@ -16,8 +16,16 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"strings"
+)
+
+const (
+	// NewUIURLEnv 新 UI 路径/地址对应的环境变量，用于不便于修改配置文件时通过环境变量覆盖
+	NewUIURLEnv = "BK_BSCP_NEW_UI_URL"
+	// OldUIURLEnv 旧 UI 路径/地址对应的环境变量，用于不便于修改配置文件时通过环境变量覆盖
+	OldUIURLEnv = "BK_BSCP_OLD_UI_URL"
 )
 
 // HostConf host conf
@@ -30,6 +38,18 @@ type HostConf struct {
 	BKSharedResBaseJSURL string `yaml:"-"`                 // 规则是${bkSharedResUrl}/${目录名 aka app_code}/base.js
 	UserManHost          string `yaml:"user_man_host"`     // 用户列表host
 	UserCenterURL        string `yaml:"user_center_url"`   // 用户中心(个人中心)跳转地址
+	NewUIURL             string `yaml:"new_ui_url"`        // 新 UI 路径/地址
+	OldUIURL             string `yaml:"old_ui_url"`        // 旧 UI 路径/地址
+}
+
+// getFromEnv 从环境变量补充配置，仅当对应字段为空时读取，避免覆盖显式配置
+func (h *HostConf) getFromEnv() {
+	if h.NewUIURL == "" {
+		h.NewUIURL = os.Getenv(NewUIURLEnv)
+	}
+	if h.OldUIURL == "" {
+		h.OldUIURL = os.Getenv(OldUIURLEnv)
+	}
 }
 
 // FrontendConf docs and host conf

--- a/pkg/config/frontend_test.go
+++ b/pkg/config/frontend_test.go
@@ -29,3 +29,30 @@ func TestInitResBaseJSURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "http://repo.test.com/bk_bscp/base.js", conf.Host.BKSharedResBaseJSURL)
 }
+
+func TestHostConfGetFromEnv(t *testing.T) {
+	// 字段为空时, 从环境变量补充
+	t.Run("fill from env when empty", func(t *testing.T) {
+		t.Setenv(NewUIURLEnv, "https://new-ui.example.com")
+		t.Setenv(OldUIURLEnv, "https://old-ui.example.com")
+
+		h := &HostConf{}
+		h.getFromEnv()
+		assert.Equal(t, "https://new-ui.example.com", h.NewUIURL)
+		assert.Equal(t, "https://old-ui.example.com", h.OldUIURL)
+	})
+
+	// 字段非空时, 显式配置优先, 不被环境变量覆盖
+	t.Run("keep explicit config", func(t *testing.T) {
+		t.Setenv(NewUIURLEnv, "https://new-ui.example.com")
+		t.Setenv(OldUIURLEnv, "https://old-ui.example.com")
+
+		h := &HostConf{
+			NewUIURL: "https://explicit-new.example.com",
+			OldUIURL: "https://explicit-old.example.com",
+		}
+		h.getFromEnv()
+		assert.Equal(t, "https://explicit-new.example.com", h.NewUIURL)
+		assert.Equal(t, "https://explicit-old.example.com", h.OldUIURL)
+	})
+}


### PR DESCRIPTION
- HostConf 新增 OldUIURL 字段及 BK_BSCP_OLD_UI_URL 环境变量
- IndexConfig 注入 OLD_UI_URL, 渲染层对称补全新/旧 UI 跳转地址
- 新 UI 源码模板补充 OLD_UI_URL; 旧 UI 模板补充 NEW_UI_URL/OLD_UI_URL
- 示例配置与单测同步更新, 验证 env 为空时补充、非空时显式配置优先