### PR TITLE
--bug=163290517 fix: 创建模板时审计 res_instance 混入无关路径且新增 config_template_name 展示

### DIFF
--- a/cmd/data-service/service/config_template.go
+++ b/cmd/data-service/service/config_template.go
@@ -539,12 +539,10 @@ func (s *Service) createTemplateAndRevision(kit *kit.Kit, tx *gen.QueryTx, templ
 			i18n.T(kit, "create template revision failed, err: %v", err))
 	}
 
-	templateSet.Spec.TemplateIDs = tools.MergeAndDeduplicate(templateSet.Spec.TemplateIDs, []uint32{templateID})
-
-	// 3. 添加至模板套餐中
-	err = s.dao.TemplateSet().BatchAddTmplsToTmplSetsWithTx(kit, tx, []*table.TemplateSet{templateSet}, true)
-	if err != nil {
-		logs.Errorf("batch add templates to template sets failed, err: %v, rid: %s", err, kit.Rid)
+	// 3. 添加至模板套餐中, 审计仅记录本次新增的模板
+	if err := s.dao.TemplateSet().AddTmplsToTmplSetsWithAuditTx(kit, tx, []uint32{templateID},
+		[]*table.TemplateSet{templateSet}); err != nil {
+		logs.Errorf("add template to template sets failed, err: %v, rid: %s", err, kit.Rid)
 		return 0, errf.Errorf(errf.DBOpFailed, "%s", i18n.T(kit, "batch add templates to template sets failed, err: %s", err))
 	}
 

--- a/cmd/data-service/service/template.go
+++ b/cmd/data-service/service/template.go
@@ -157,13 +157,9 @@ func (s *Service) CreateTemplate(ctx context.Context, req *pbds.CreateTemplateRe
 		}
 	}
 
-	for _, v := range templateSets {
-		v.Spec.TemplateIDs = tools.MergeAndDeduplicate(v.Spec.TemplateIDs, []uint32{templateID})
-	}
-
-	// 9. 添加至模板套餐中
-	if err := s.dao.TemplateSet().BatchAddTmplsToTmplSetsWithTx(kt, tx, templateSets, true); err != nil {
-		logs.Errorf("batch add templates to template sets failed, err: %v, rid: %s", err, kt.Rid)
+	// 9. 添加至模板套餐中, 审计仅记录本次新增的模板
+	if err := s.dao.TemplateSet().AddTmplsToTmplSetsWithAuditTx(kt, tx, []uint32{templateID}, templateSets); err != nil {
+		logs.Errorf("add template to template sets failed, err: %v, rid: %s", err, kt.Rid)
 		return nil, errf.Errorf(errf.DBOpFailed, i18n.T(kt, "batch add templates to template sets failed, err: %s", err))
 	}
 

--- a/internal/dal/dao/template_set.go
+++ b/internal/dal/dao/template_set.go
@@ -85,6 +85,8 @@ type TemplateSet interface {
 	GetByTemplateSetByID(kit *kit.Kit, bizID, id uint32) (*table.TemplateSet, error)
 	// BatchAddTmplsToTmplSetsWithTx 批量添加至某个套餐中
 	BatchAddTmplsToTmplSetsWithTx(kit *kit.Kit, tx *gen.QueryTx, templateSet []*table.TemplateSet, needAudit bool) error
+	// AddTmplsToTmplSetsWithAuditTx 将模板添加至套餐中, 审计的 res_instance 仅记录本次新增的模板路径.
+	AddTmplsToTmplSetsWithAuditTx(kit *kit.Kit, tx *gen.QueryTx, tmplIDs []uint32, tmplSets []*table.TemplateSet) error
 	// ListByTemplateSpaceIdAndIds list template sets by template set ids and template_space_id.
 	ListByTemplateSpaceIdAndIds(kit *kit.Kit, templateSpaceID uint32, ids []uint32) ([]*table.TemplateSet, error)
 
@@ -212,6 +214,64 @@ func (dao *templateSetDao) BatchAddTmplsToTmplSetsWithTx(kit *kit.Kit, tx *gen.Q
 	}
 
 	return tx.TemplateSet.WithContext(kit.Ctx).Save(templateSet...)
+}
+
+// AddTmplsToTmplSetsWithAuditTx 将模板添加至套餐中并记录审计.
+// 与 BatchAddTmplsToTmplSetsWithTx 不同, 审计的 res_instance 仅记录本次新增的模板路径,
+// 不包含套餐内已有的模板, 避免操作记录中出现与本次操作无关的模板路径.
+// 若本次新增的模板关联了配置模板名称(配置模板场景), 额外记录 config_template_name;
+// 普通模板场景无配置模板名称, res_instance 保持原有格式不变.
+func (dao *templateSetDao) AddTmplsToTmplSetsWithAuditTx(kit *kit.Kit, tx *gen.QueryTx,
+	tmplIDs []uint32, tmplSets []*table.TemplateSet) error {
+	if len(tmplSets) == 0 {
+		return nil
+	}
+
+	// 仅查询本次新增的模板, 用于审计记录
+	templates, err := tx.Template.WithContext(kit.Ctx).Where(tx.Template.ID.In(tmplIDs...)).Find()
+	if err != nil {
+		return err
+	}
+
+	var templateNames []string
+	var configTemplateNames []string
+	for _, v := range templates {
+		templateNames = append(templateNames, path.Join(v.Spec.Path, v.Spec.Name))
+		if v.Spec.ConfigTemplateName != "" {
+			configTemplateNames = append(configTemplateNames, v.Spec.ConfigTemplateName)
+		}
+	}
+	tmplPaths := tools.TruncateWithHumanize(strings.Join(templateNames, constant.NameSeparator))
+
+	for i := range tmplSets {
+		tmplSets[i].Spec.TemplateIDs = tools.MergeAndDeduplicate(tmplSets[i].Spec.TemplateIDs, tmplIDs)
+
+		templateSpace, err := tx.TemplateSpace.WithContext(kit.Ctx).
+			Where(tx.TemplateSpace.ID.Eq(tmplSets[i].Attachment.TemplateSpaceID)).Take()
+		if err != nil {
+			return err
+		}
+
+		resInstance := fmt.Sprintf(constant.TemplateSpaceName+constant.ResSeparator+constant.TemplateSetName+
+			constant.ResSeparator+constant.TemplateAbsolutePath,
+			templateSpace.Spec.Name, tmplSets[i].Spec.Name, tmplPaths)
+		if len(configTemplateNames) > 0 {
+			resInstance = fmt.Sprintf(constant.TemplateSpaceName+constant.ResSeparator+constant.TemplateSetName+
+				constant.ResSeparator+constant.ConfigTemplateName+constant.ResSeparator+constant.TemplateAbsolutePath,
+				templateSpace.Spec.Name, tmplSets[i].Spec.Name,
+				strings.Join(configTemplateNames, constant.NameSeparator), tmplPaths)
+		}
+
+		ad := dao.auditDao.Decorator(kit, tmplSets[i].Attachment.BizID, &table.AuditField{
+			ResourceInstance: resInstance,
+			Status:           enumor.Success,
+		}).PrepareCreate(tmplSets[i])
+		if err = ad.Do(tx.Query); err != nil {
+			return err
+		}
+	}
+
+	return tx.TemplateSet.WithContext(kit.Ctx).Save(tmplSets...)
 }
 
 // GetByTemplateSetByID get template set by id

--- a/ui/src/constants/record.ts
+++ b/ui/src/constants/record.ts
@@ -35,6 +35,7 @@ export const INSTANCE = {
   template_set_name: localT('模版套餐名称'),
   template_absolute_path: localT('模版文件绝对路径'),
   template_revision: localT('模版版本号'),
+  config_template_name: localT('模板名称'),
   credential_name: localT('密钥名称'),
   hook_revision_name: localT('脚本版本号'),
   reference_pre_hook_name: localT('引用前置脚本名称'),

--- a/ui_old/src/constants/record.ts
+++ b/ui_old/src/constants/record.ts
@@ -35,6 +35,7 @@ export const INSTANCE = {
   template_set_name: localT('模版套餐名称'),
   template_absolute_path: localT('模版文件绝对路径'),
   template_revision: localT('模版版本号'),
+  config_template_name: localT('模板名称'),
   credential_name: localT('密钥名称'),
   hook_revision_name: localT('脚本版本号'),
   reference_pre_hook_name: localT('引用前置脚本名称'),


### PR DESCRIPTION
- 新增 AddTmplsToTmplSetsWithAuditTx 方法, 审计 res_instance 仅记录本次新增的模板路径, 不再写入套餐内已有模板
- CreateConfigTemplate / CreateTemplate 改用新方法, 避免操作记录出现无关模板路径
- 配置模板场景自动补录 config_template_name 段
- 前端 INSTANCE 映射表补充 config_template_name, 修复操作记录展示英文 key 原文问题
- 英文语言包模板名称统一为 Title Case (Template Name)