### PR TITLE
--bug=163366817 fix: 进程实例拓扑接口超时治理

### DIFF
--- a/cmd/data-service/db-migration/migrations/20260901175736_add_process_instance_topo_index.go
+++ b/cmd/data-service/db-migration/migrations/20260901175736_add_process_instance_topo_index.go
@@ -1,0 +1,60 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/TencentBlueKing/bk-bscp/cmd/data-service/db-migration/migrator"
+)
+
+func init() {
+	// add current migration to migrator
+	migrator.GetMigrator().AddMigration(&migrator.Migration{
+		Version: "20260901175736",
+		Name:    "20260901175736_add_process_instance_topo_index",
+		Mode:    migrator.GormMode,
+		Up:      mig20260901175736Up,
+		Down:    mig20260901175736Down,
+	})
+}
+
+// mig20260901175736Up for up migration
+func mig20260901175736Up(tx *gorm.DB) error {
+	var count int64
+	if err := tx.Raw(
+		`SELECT COUNT(*) FROM information_schema.statistics
+		WHERE table_schema = DATABASE()
+		AND table_name = 'process_instances'
+		AND index_name = 'idx_processID_status_managedStatus'`,
+	).Scan(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	return tx.Exec(
+		"ALTER TABLE process_instances ADD INDEX idx_processID_status_managedStatus (process_id, status, managed_status)",
+	).Error
+}
+
+// mig20260901175736Down for down migration
+func mig20260901175736Down(tx *gorm.DB) error {
+	// The index may have existed before this migration (for example, it may
+	// have been created manually during the incident). Since this migration
+	// cannot distinguish ownership of an existing index, do not drop it on
+	// rollback.
+
+	return nil
+}

--- a/cmd/data-service/service/process.go
+++ b/cmd/data-service/service/process.go
@@ -855,15 +855,15 @@ func (s *Service) GetProcessInstanceTopo(ctx context.Context, req *pbds.GetProce
 	*pbds.GetProcessInstanceTopoResp, error) {
 	kt := kit.FromGrpcContext(ctx)
 
-	processes, count, err := s.dao.Process().List(kt, req.BizId, nil, &types.BasePage{
-		All: true,
-	})
+	// 拓扑构建仅需少量字段，使用列裁剪的精简查询，避免全字段（含 source_data/prev_data
+	// 大字段）全量拉取；过滤条件与进程列表一致（未删除或存在运行中/托管中实例）。
+	processes, err := s.dao.Process().ListTopoProcesses(kt, req.BizId)
 	if err != nil {
 		return nil, errf.Errorf(errf.DBOpFailed, "%s",
 			i18n.T(kt, "list processes failed for process instance topo, err: %v", err))
 	}
 
-	if count == 0 {
+	if len(processes) == 0 {
 		return &pbds.GetProcessInstanceTopoResp{}, nil
 	}
 

--- a/internal/dal/dao/process.go
+++ b/internal/dal/dao/process.go
@@ -38,6 +38,8 @@ type Process interface {
 	// List released config items with options.
 	List(kit *kit.Kit, bizID uint32, search *process.ProcessSearchCondition,
 		opt *types.BasePage) ([]*table.Process, int64, error)
+	// ListTopoProcesses 查询构建进程实例拓扑所需的进程字段（列裁剪 + 两阶段过滤，无分页）。
+	ListTopoProcesses(kit *kit.Kit, bizID uint32) ([]*table.Process, error)
 	// BatcheUpsertWithTx 批量更新插入数据
 	BatcheUpsertWithTx(kit *kit.Kit, tx *gen.QueryTx, data []*table.Process) error
 	// BatchCreateWithTx batch create client instances with transaction.
@@ -282,12 +284,23 @@ func (dao *processDao) UpdateSelectedFields(kit *kit.Kit, bizID uint32, data map
 }
 
 // ListProcessesWithInstance implements Process.
+// 两阶段查询：先查出该业务下存在实例的进程 ID，再做 IN 集合过滤，
+// 替代原有无法命中索引的 EXISTS 依赖子查询（其唯一等值条件 process_id 位于
+// idx_tenantID_bizID_ccProcessID_processID 的第 4 列，不满足最左前缀原则）。
 func (dao *processDao) ListProcessesWithInstance(kit *kit.Kit, bizID uint32) ([]*table.Process, error) {
 	m := dao.genQ.Process
-	q := dao.genQ.Process.WithContext(kit.Ctx)
+	instQ := dao.genQ.ProcessInstance
 
-	return q.Where(m.BizID.Eq(bizID)).Where(utils.RawCond(
-		"EXISTS (SELECT 1 FROM process_instances pi WHERE pi.process_id = processes.id)")).
+	var pids []uint32
+	if err := instQ.WithContext(kit.Ctx).
+		Distinct(instQ.ProcessID).
+		Where(instQ.BizID.Eq(bizID)).
+		Pluck(instQ.ProcessID, &pids); err != nil {
+		return nil, err
+	}
+
+	return dao.genQ.Process.WithContext(kit.Ctx).
+		Where(m.BizID.Eq(bizID), m.ID.In(pids...)).
 		Find()
 }
 
@@ -305,23 +318,44 @@ func (dao *processDao) GetByID(kit *kit.Kit, bizID uint32, id uint32) (*table.Pr
 // environment 为空时不按环境过滤，非空时仅返回该环境的数据。
 func (dao *processDao) ListBizFilterOptions(kit *kit.Kit, bizID uint32, environment string, fields ...field.Expr) (
 	[]*table.Process, error) {
-	sql := `processes.cc_sync_status != ?
-			OR EXISTS (
-			SELECT 1
-			FROM process_instances AS pl
-			WHERE pl.process_id = processes.id
-			AND (pl.status = ? OR pl.managed_status = ?)
-			)`
+	pids, err := dao.listRunningOrManagedProcessIDs(kit, bizID)
+	if err != nil {
+		return nil, err
+	}
 
+	m := dao.genQ.Process
 	q := dao.genQ.Process.WithContext(kit.Ctx).
-		Where(dao.genQ.Process.BizID.Eq(bizID)).
-		Where(utils.RawCond(sql, "deleted", "running", "managed"))
+		Where(m.BizID.Eq(bizID)).
+		Where(field.Or(m.CcSyncStatus.Neq(table.Deleted.String()), m.ID.In(pids...)))
 
 	if environment != "" {
-		q = q.Where(dao.genQ.Process.Environment.Eq(environment))
+		q = q.Where(m.Environment.Eq(environment))
 	}
 
 	return q.Distinct(fields...).Select(fields...).Find()
+}
+
+// listRunningOrManagedProcessIDs 查询存在「运行中」或「托管中」进程实例的进程 ID 集合，
+// 是进程列表/拓扑类查询两阶段方案的第一阶段：本查询经 gorm 租户回调注入 tenant_id 条件后，
+// 可稳定命中 process_instances 的 (tenant_id, biz_id) 索引前缀；返回的 ID 集合用于第二阶段的
+// IN 过滤，替代原有逐行探测的 EXISTS 依赖子查询。pids 为空时 IN (NULL) 恒为假，
+// 第二阶段自然退化为仅保留 cc_sync_status != 'deleted' 的进程。
+func (dao *processDao) listRunningOrManagedProcessIDs(kit *kit.Kit, bizID uint32) ([]uint32, error) {
+	instQ := dao.genQ.ProcessInstance
+
+	var pids []uint32
+	if err := instQ.WithContext(kit.Ctx).
+		Distinct(instQ.ProcessID).
+		Where(instQ.BizID.Eq(bizID)).
+		Where(field.Or(
+			instQ.Status.Eq(table.ProcessStatusRunning.String()),
+			instQ.ManagedStatus.Eq(table.ProcessManagedStatusManaged.String()),
+		)).
+		Pluck(instQ.ProcessID, &pids); err != nil {
+		return nil, err
+	}
+
+	return pids, nil
 }
 
 func (dao *processDao) GetByIDs(kit *kit.Kit, bizID uint32, id []uint32) ([]*table.Process, error) {
@@ -412,14 +446,16 @@ func (dao *processDao) List(kit *kit.Kit, bizID uint32, search *process.ProcessS
 
 	// processes 状态不能是删除状态
 	// process_instances 的进程状态和托管状态只要有一条数据是运行中或者托管中的都需要显示
-	sql := `processes.cc_sync_status != ?
-			OR EXISTS (
-			SELECT 1
-			FROM process_instances AS pl
-			WHERE pl.process_id = processes.id
-			AND (pl.status = ? OR pl.managed_status = ?)
-			)`
-	conds = append(conds, q.Where(utils.RawCond(sql, "deleted", "running", "managed")))
+	// 两阶段查询：先查出存在运行中/托管中实例的进程 ID（阶段一命中 process_instances 的
+	// (tenant_id, biz_id) 索引前缀），再做 IN 集合过滤，替代原有逐行探测的 EXISTS 依赖子查询。
+	pids, err := dao.listRunningOrManagedProcessIDs(kit, bizID)
+	if err != nil {
+		return nil, 0, err
+	}
+	conds = append(conds, q.Where(field.Or(
+		m.CcSyncStatus.Neq(table.Deleted.String()),
+		m.ID.In(pids...),
+	)))
 
 	d := q.Where(m.BizID.Eq(bizID)).Where(conds...).Order(m.ID.Desc())
 
@@ -431,6 +467,26 @@ func (dao *processDao) List(kit *kit.Kit, bizID uint32, search *process.ProcessS
 		return result, int64(len(result)), err
 	}
 	return d.FindByPage(opt.Offset(), opt.LimitInt())
+}
+
+// ListTopoProcesses implements Process.
+// 拓扑构建仅使用 set/module/service_instance/cc_process_id/alias/proc_num 少量字段，
+// 列裁剪避免 source_data/prev_data 等大字段的扫描与传输；过滤条件与 List 保持一致。
+func (dao *processDao) ListTopoProcesses(kit *kit.Kit, bizID uint32) ([]*table.Process, error) {
+	m := dao.genQ.Process
+	q := dao.genQ.Process.WithContext(kit.Ctx)
+
+	pids, err := dao.listRunningOrManagedProcessIDs(kit, bizID)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.
+		Select(m.SetID, m.SetName, m.ModuleID, m.ModuleName, m.ServiceInstanceID, m.ServiceName,
+			m.CcProcessID, m.Alias_, m.ProcNum).
+		Where(m.BizID.Eq(bizID)).
+		Where(field.Or(m.CcSyncStatus.Neq(table.Deleted.String()), m.ID.In(pids...))).
+		Find()
 }
 
 func (dao *processDao) handleSearch(kit *kit.Kit, bizID uint32,

--- a/internal/dal/dao/process_two_phase_test.go
+++ b/internal/dal/dao/process_two_phase_test.go
@@ -1,0 +1,80 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dao
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/gen/field"
+)
+
+// TestAliveProcessCondOrGrouping 锁定进程两阶段查询第二阶段的条件语义：
+// 「cc_sync_status != 'deleted' OR id IN (...)」必须渲染为整体带括号的 OR 组，
+// 作为单个条件参与外层 AND 组合。若丢括号，AND 优先级高于 OR 会把 biz_id 等前置条件
+// 卷进 OR 右侧，放大查询范围（对齐 hook.go 中对 field.Or 的同类约束）。
+func TestAliveProcessCondOrGrouping(t *testing.T) {
+	ccSyncStatus := field.NewString("processes", "cc_sync_status")
+	id := field.NewUint32("processes", "id")
+
+	var sb strings.Builder
+	field.Or(ccSyncStatus.Neq("deleted"), id.In(uint32(1), uint32(2))).
+		Build(&sqlFragmentBuilder{sb: &sb})
+	got := sb.String()
+
+	if !strings.HasPrefix(got, "(") || !strings.HasSuffix(got, ")") {
+		t.Fatalf("OR 组必须整体带括号，实际片段: %s", got)
+	}
+	if !strings.Contains(got, "cc_sync_status") {
+		t.Fatalf("应包含 cc_sync_status 条件，实际片段: %s", got)
+	}
+	if !strings.Contains(got, "id IN") {
+		t.Fatalf("应包含 id IN 条件，实际片段: %s", got)
+	}
+}
+
+// TestAliveProcessCondEmptyIDs 锁定阶段一结果为空集的语义：
+// 阶段一（运行中/托管中实例的进程 ID）为空时，id IN (空) 渲染为 IN (NULL) 恒为假，
+// 第二阶段自然退化为仅保留 cc_sync_status != 'deleted' 的进程，且不产生 SQL 语法错误。
+func TestAliveProcessCondEmptyIDs(t *testing.T) {
+	id := field.NewUint32("processes", "id")
+	var empty []uint32
+
+	var sb strings.Builder
+	id.In(empty...).Build(&sqlFragmentBuilder{sb: &sb})
+	got := sb.String()
+
+	if !strings.Contains(got, "IN (NULL)") {
+		t.Fatalf("空 ID 集应渲染为 IN (NULL)，实际片段: %s", got)
+	}
+}
+
+// TestRunningOrManagedInstanceCond 锁定阶段一的条件语义：
+// 「status = 'running' OR managed_status = 'managed'」渲染为带括号 OR 组，
+// 与 tenant_id/biz_id 等前置 AND 条件组合时不会因优先级问题放大扫描范围。
+func TestRunningOrManagedInstanceCond(t *testing.T) {
+	status := field.NewString("process_instances", "status")
+	managedStatus := field.NewString("process_instances", "managed_status")
+
+	var sb strings.Builder
+	field.Or(status.Eq("running"), managedStatus.Eq("managed")).
+		Build(&sqlFragmentBuilder{sb: &sb})
+	got := sb.String()
+
+	if !strings.HasPrefix(got, "(") || !strings.HasSuffix(got, ")") {
+		t.Fatalf("OR 组必须整体带括号，实际片段: %s", got)
+	}
+	if !strings.Contains(got, "status") || !strings.Contains(got, "managed_status") {
+		t.Fatalf("应包含 status 与 managed_status 条件，实际片段: %s", got)
+	}
+}

--- a/pkg/criteria/errf/code.go
+++ b/pkg/criteria/errf/code.go
@@ -159,6 +159,10 @@ var (
 
 		// bscp专用错误码
 		AppNotExists: "APP_NOT_EXISTS",
+
+		// 旧错误码：DB 操作失败属服务端错误，登记为 INTERNAL，
+		// 避免未登记时被兜底为 INVALID_REQUEST + HTTP 400 误导排查方向
+		DBOpFailed: "INTERNAL",
 	}
 
 	// BscpStatusMap bscp错误码->状态映射
@@ -201,5 +205,8 @@ var (
 
 		// bscp专用错误码
 		AppNotExists: http.StatusNotFound,
+
+		// 旧错误码：与 BscpCodeMap 中 DBOpFailed -> INTERNAL 对应
+		DBOpFailed: http.StatusInternalServerError,
 	}
 )


### PR DESCRIPTION
- 新增 migration 固化 idx_processID_status_managedStatus 覆盖索引，已存在时跳过避免重复报错
- 将 List/ListBizFilterOptions/ListProcessesWithInstance 的 EXISTS 依赖子查询改写为两阶段查询，阶段一命中 process_instances 的 (tenant_id, biz_id) 索引前缀
- 新增 ListTopoProcesses 仅 Select 拓扑所需字段，GetProcessInstanceTopo 避免全字段无分页拉取