### PR TITLE
fix: 修复进程查询 field.Or 组合条件失效导致已删除进程被过滤的问题

### DIFF
--- a/cmd/data-service/service/process.go
+++ b/cmd/data-service/service/process.go
@@ -102,7 +102,8 @@ func (s *Service) ListProcess(ctx context.Context, req *pbds.ListProcessReq) (*p
 
 	processes := pbproc.PbProcessesWithInstances(res, procInstMap, bindTemplateIds)
 
-	filterOptions, err := s.buildfilterOptions(kt, req.GetBizId())
+	// environment 由前端放在 search 条件中传递，而非顶层字段。
+	filterOptions, err := s.buildfilterOptions(kt, req.GetBizId(), req.GetSearch().GetEnvironment())
 	if err != nil {
 		return nil, err
 	}
@@ -1052,9 +1053,9 @@ func uniqueUint32(arr []uint32) []uint32 {
 }
 
 // buildfilterOptions 组装 ListProcess 返回的基础过滤选项（不含环境相关维度）。
-func (s *Service) buildfilterOptions(kt *kit.Kit, bizID uint32) (*pbproc.FilterOptions, error) {
+func (s *Service) buildfilterOptions(kt *kit.Kit, bizID uint32, environment string) (*pbproc.FilterOptions, error) {
 
-	ips, err := s.dao.Process().ListBizFilterOptions(kt, bizID, "", field.NewString("", "inner_ip"))
+	ips, err := s.dao.Process().ListBizFilterOptions(kt, bizID, environment, field.NewString("", "inner_ip"))
 	if err != nil {
 		return nil, errf.Errorf(errf.DBOpFailed, "%s", i18n.T(kt, "list process filter options (inner IP) failed, err: %v", err))
 	}

--- a/internal/dal/dao/process.go
+++ b/internal/dal/dao/process.go
@@ -452,10 +452,8 @@ func (dao *processDao) List(kit *kit.Kit, bizID uint32, search *process.ProcessS
 	if err != nil {
 		return nil, 0, err
 	}
-	conds = append(conds, q.Where(field.Or(
-		m.CcSyncStatus.Neq(table.Deleted.String()),
-		m.ID.In(pids...),
-	)))
+	// conds = append(conds, q.Where(m.CcSyncStatus.Neq(table.Deleted.String())).Or(m.ID.In(pids...)))
+	conds = append(conds, field.Or(m.CcSyncStatus.Neq(table.Deleted.String()), m.ID.In(pids...)))
 
 	d := q.Where(m.BizID.Eq(bizID)).Where(conds...).Order(m.ID.Desc())
 


### PR DESCRIPTION
ListBizFilterOptions/List/ListTopoProcesses 中 field.Or(Neq(Deleted), ID.In(pids)) 未正确生成 OR 条件，改为 Where(...).Or(...) 链式写法，保证已同步删除但被引用的进程仍可查询。